### PR TITLE
fixed spriteSize typo

### DIFF
--- a/Source/PyBoy/BotSupport/Sprite.py
+++ b/Source/PyBoy/BotSupport/Sprite.py
@@ -35,7 +35,8 @@ class Sprite():
             }
 
     def is_on_screen(self):
-        spriteHeight = 16 if self.LCDC.spriteSize else 16
+        #spriteHeight = 16 if self.LCDC.spriteSize else 16
+        spriteHeight = 16 if self.LCDC.sprite_size else 16
         return (0 < self.get_y() < 144+spriteHeight) and (0 < self.get_x() < 160+8)
 
 def get_bit(val, bit):

--- a/Source/PyBoy/GameWindow/GameWindow_SDL2.py
+++ b/Source/PyBoy/GameWindow/GameWindow_SDL2.py
@@ -457,5 +457,6 @@ class SdlGameWindow(AbstractGameWindow):
 
             i = n*2
             self.copyTile(fromXY, (i%self.spriteWidth, (i/self.spriteWidth)*16), self.sprite_cacheOBP0, self.spriteBuffer)
-            if lcd.LCDC.spriteSize:
+            # if lcd.LCDC.spriteSize:
+            if lcd.LCDC.sprite_size:
                 self.copyTile((tileIndex * 8+8, 0), (i%self.spriteWidth, (i/self.spriteWidth)*16 + 8), self.sprite_cacheOBP0, self.spriteBuffer)


### PR DESCRIPTION
tetris_bot.py was broken because of a couple of typos like this:
"/PyBoy/Source/PyBoy/GameWindow/GameWindow_SDL2.py", line 460, in refreshSpriteView
    if lcd.LCDC.spriteSize:
AttributeError: LCDCRegister instance has no attribute 'spriteSize'
