### PR TITLE
Easier installation and more Git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,12 @@ ROMs/
 diffDump.txt
 Core_Dump_*
 *.state
+
+# Files from venv and dependencies
+Source/bin
+Source/include
+Source/lib-python
+Source/lib_pypy
+Source/pip-selfcheck.json
+Source/site-packages
+

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ When brew is installed, the depencencies can be installed with the following com
     brew install git pypy sdl2 sdl2_gfx sdl2_image
     brew link sdl2
 
-    pip_pypy install git+https://bitbucket.org/pypy/numpy.git
-    pip_pypy install git+https://github.com/marcusva/py-sdl2.git
+    pip_pypy install -r requirements.txt
 
 
 Ubuntu/Linux
@@ -60,11 +59,10 @@ Ubuntu has some problems installing PyPy in parallel with the system version of 
 
 Now move to the `PyBoy/Source` directory before creating the virtual environment:
 
-    virtualenv . -p `which pypy`
+    virtualenv . -p $(which pypy)
     source ./bin/activate
 
-    pip install git+https://bitbucket.org/pypy/numpy.git
-    pip install git+https://github.com/marcusva/py-sdl2.git
+    pip install -r requirements.txt
 
 Windows
 -------
@@ -86,8 +84,7 @@ Start a Command Prompt and run the following:
 
     pypy -m ensurepip
     pypy -m pip install -U pip wheel
-    pypy -m pip install git+https://bitbucket.org/pypy/numpy.git
-    pypy -m pip install git+https://github.com/marcusva/py-sdl2.git
+    pypy -m pip install -r requirements.txt
 
 Download SDL2 Runtime Binaries for 32-bit Windows:
 

--- a/Source/requirements.txt
+++ b/Source/requirements.txt
@@ -1,0 +1,4 @@
+git+https://bitbucket.org/pypy/numpy.git
+git+https://github.com/marcusva/py-sdl2.git
+imageio
+


### PR DESCRIPTION
Hey, I wanted to try your emulator out and noticed some potential improvements on the first setup:

- IMHO having a requirements.txt file makes the setup easier.
- The imageio dependency was missing in the README.md (added it to requirements.txt).
- Added some more lines to the .gitignore file. These files were created by pip after installing the dependencies, IMHO it is convenient to let Git ignore them. I don't know if this is specific to my environment but I'd wonder if this hurt anyone.

Grats on the nice emulator! :)