### PR TITLE
Python3-friendly imports and print()

### DIFF
--- a/Source/PyBoy/BotSupport/__init__.py
+++ b/Source/PyBoy/BotSupport/__init__.py
@@ -5,5 +5,5 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-from Sprite import Sprite
-from TileView import TileView
+from .Sprite import Sprite
+from .TileView import TileView

--- a/Source/PyBoy/CPU/Interrupts.py
+++ b/Source/PyBoy/CPU/Interrupts.py
@@ -5,7 +5,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-from flags import VBlank, LCDC, TIMER, Serial, HightoLow
+from .flags import VBlank, LCDC, TIMER, Serial, HightoLow
 
 # Order important. NoInterrupt evaluates to False in if statements
 NoInterrupt, InterruptVector = range(0,2)

--- a/Source/PyBoy/CPU/__init__.py
+++ b/Source/PyBoy/CPU/__init__.py
@@ -7,19 +7,19 @@
 
 from .. import CoreDump
 from ..OpcodeToName import CPU_COMMANDS, CPU_COMMANDS_EXT
-from flags import flagZ, flagN, flagH, flagC
+from .flags import flagZ, flagN, flagH, flagC
 from ..Logger import logger
-from Interrupts import InterruptVector, NoInterrupt
+from .Interrupts import InterruptVector, NoInterrupt
 import numpy as np
 
 class CPU(object): # 'object' is important for property!!!
-    from opcodes import opcodes
-    from registers import A, F, B, C, D, E, HL, SP, PC
-    from registers import setH, setL, setAF, setBC, setDE
-    from Interrupts import checkForInterrupts, testAndTriggerInterrupt
-    from flags import VBlank, LCDC, TIMER, Serial, HightoLow
-    from flags import testFlag, setFlag, clearFlag
-    from flags import testInterruptFlag, setInterruptFlag, clearInterruptFlag, testInterruptFlagEnabled, testRAMRegisterFlag
+    from .opcodes import opcodes
+    from .registers import A, F, B, C, D, E, HL, SP, PC
+    from .registers import setH, setL, setAF, setBC, setDE
+    from .Interrupts import checkForInterrupts, testAndTriggerInterrupt
+    from .flags import VBlank, LCDC, TIMER, Serial, HightoLow
+    from .flags import testFlag, setFlag, clearFlag
+    from .flags import testInterruptFlag, setInterruptFlag, clearInterruptFlag, testInterruptFlagEnabled, testRAMRegisterFlag
 
     H = property(lambda s: s.HL >> 8, setH)
     L = property(lambda s: s.HL & 0xFF, setL)
@@ -131,9 +131,9 @@ class CPU(object): # 'object' is important for property!!!
         if __debug__:
             if self.lala and not self.halted:
                 if (self.mb[self.PC]) == 0xCB:
-                    print "%0.4x CB%0.2x AF:%0.4x BC:%0.4x DE%0.4x HL%0.4x SP%0.4x" % (self.PC, self.mb[self.PC+1], self.AF, self.BC, self.DE, self.HL, self.SP)
+                    print("%0.4x CB%0.2x AF:%0.4x BC:%0.4x DE%0.4x HL%0.4x SP%0.4x" % (self.PC, self.mb[self.PC+1], self.AF, self.BC, self.DE, self.HL, self.SP))
                 else:
-                    print "%0.4x %0.2x AF:%0.4x BC:%0.4x DE%0.4x HL%0.4x SP%0.4x" % (self.PC, self.mb[self.PC], self.AF, self.BC, self.DE, self.HL, self.SP)
+                    print("%0.4x %0.2x AF:%0.4x BC:%0.4x DE%0.4x HL%0.4x SP%0.4x" % (self.PC, self.mb[self.PC], self.AF, self.BC, self.DE, self.HL, self.SP))
 
             if self.breakAllow and self.PC == self.breakNext and self.AF == 0x1f80:
                 self.breakAllow = False
@@ -142,7 +142,7 @@ class CPU(object): # 'object' is important for property!!!
             if self.oldPC == self.PC and not self.halted:
                 self.breakOn = True
                 logger.info("PC DIDN'T CHANGE! Can't continue!")
-                print self.getDump()
+                print(self.getDump())
                 # CoreDump.windowHandle.dump(self.mb.cartridge.filename+"_dump.bmp")
                 raise Exception("Escape to main.py")
             self.oldPC = self.PC
@@ -200,7 +200,7 @@ class CPU(object): # 'object' is important for property!!!
         if self.testFlag(flagN):
             flags += " N"
 
-	logger.info(flags)
+        logger.info(flags)
         logger.info("A:   0x%0.2X   F: 0x%0.2X" % (self.A, self.F))
         logger.info("B:   0x%0.2X   C: 0x%0.2X" % (self.B, self.C))
         logger.info("D:   0x%0.2X   E: 0x%0.2X" % (self.D, self.E))
@@ -241,7 +241,7 @@ class CPU(object): # 'object' is important for property!!!
             flags += "Serial "
         if self.testInterruptFlagEnabled(self.HightoLow):
             flags += "HightoLow "
-	logger.info(flags)
+        logger.info(flags)
         logger.info("Waiting Interrupts")
         flags = ""
         if self.testInterruptFlag(self.VBlank):

--- a/Source/PyBoy/CPU/opcodes.py
+++ b/Source/PyBoy/CPU/opcodes.py
@@ -3,7 +3,7 @@
 # DO NOT MODIFY THIS FILE.
 # CHANGES TO THE CODE SHOULD BE MADE IN 'generator.py'.
 
-from flags import flagZ, flagN, flagH, flagC
+from .flags import flagZ, flagN, flagH, flagC
 from ..MathUint8 import getSignedInt8
 
 def NOP_00(self): # 00 NOP

--- a/Source/PyBoy/Cartridge/GenericMBC.py
+++ b/Source/PyBoy/Cartridge/GenericMBC.py
@@ -6,7 +6,7 @@
 #
 from .. import CoreDump
 import os
-from RTC import RTC
+from .RTC import RTC
 from ..Logger import logger
 
 class GenericMBC:

--- a/Source/PyBoy/Cartridge/MBC1.py
+++ b/Source/PyBoy/Cartridge/MBC1.py
@@ -6,7 +6,7 @@
 #
 from .. import CoreDump
 from ..Logger import logger
-from GenericMBC import GenericMBC
+from .GenericMBC import GenericMBC
 
 class MBC1(GenericMBC):
     def __setitem__(self, address, value):

--- a/Source/PyBoy/Cartridge/MBC2.py
+++ b/Source/PyBoy/Cartridge/MBC2.py
@@ -5,7 +5,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 from .. import CoreDump
-from GenericMBC import GenericMBC
+from .GenericMBC import GenericMBC
 
 class MBC2(GenericMBC):
     def __setitem__(self, address, value):

--- a/Source/PyBoy/Cartridge/MBC3.py
+++ b/Source/PyBoy/Cartridge/MBC3.py
@@ -5,7 +5,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 from .. import CoreDump
-from GenericMBC import GenericMBC
+from .GenericMBC import GenericMBC
 
 from ..Logger import logger
 

--- a/Source/PyBoy/Cartridge/MBC5.py
+++ b/Source/PyBoy/Cartridge/MBC5.py
@@ -5,7 +5,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 from .. import CoreDump
-from GenericMBC import GenericMBC
+from .GenericMBC import GenericMBC
 
 class MBC5(GenericMBC):
     def __setitem__(self, address, value):

--- a/Source/PyBoy/Cartridge/__init__.py
+++ b/Source/PyBoy/Cartridge/__init__.py
@@ -9,12 +9,12 @@ from .. import CoreDump
 import os
 import struct
 
-from GenericMBC import GenericMBC
-from GenericMBC import ROM_only
-from MBC1 import MBC1
-from MBC2 import MBC2
-from MBC3 import MBC3
-from MBC5 import MBC5
+from .GenericMBC import GenericMBC
+from .GenericMBC import ROM_only
+from .MBC1 import MBC1
+from .MBC2 import MBC2
+from .MBC3 import MBC3
+from .MBC5 import MBC5
 
 from ..Logger import logger
 

--- a/Source/PyBoy/CoreDump.py
+++ b/Source/PyBoy/CoreDump.py
@@ -6,7 +6,7 @@ windowHandle = None
 
 class CoreDump(Exception):
     def __init__(self, message):
-        print "TODO: Fix CoreDump.\n",message
+        print("TODO: Fix CoreDump.\n",message)
         exit(1)
         super(CoreDump, self).__init__(message)
 

--- a/Source/PyBoy/GameWindow/GameWindow_SDL2.py
+++ b/Source/PyBoy/GameWindow/GameWindow_SDL2.py
@@ -16,7 +16,7 @@ from .. import CoreDump
 from ..MathUint8 import getSignedInt8
 from ..WindowEvent import WindowEvent
 from ..LCD import color_palette
-from FrameBuffer import SimpleFrameBuffer, ScaledFrameBuffer
+from .FrameBuffer import SimpleFrameBuffer, ScaledFrameBuffer
 from ..GameWindow import AbstractGameWindow
 
 from ..Logger import logger

--- a/Source/PyBoy/Interaction.py
+++ b/Source/PyBoy/Interaction.py
@@ -4,8 +4,8 @@
 # License: See LICENSE file
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
-from WindowEvent import WindowEvent
-import CoreDump
+from .WindowEvent import WindowEvent
+from . import CoreDump
 
 P10, P11, P12, P13, P14, P15 = range(0,6)
 

--- a/Source/PyBoy/LCD.py
+++ b/Source/PyBoy/LCD.py
@@ -5,8 +5,8 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import CoreDump
-from RAM import allocateRAM, VIDEO_RAM, OBJECT_ATTRIBUTE_MEMORY
+from . import CoreDump
+from .RAM import allocateRAM, VIDEO_RAM, OBJECT_ATTRIBUTE_MEMORY
 import numpy as np
 
 LCDC, STAT, SCY, SCX, LY, LYC, DMA, BGPalette, OBP0, OBP1, WY, WX = range(0xFF40, 0xFF4C)

--- a/Source/PyBoy/MB/__init__.py
+++ b/Source/PyBoy/MB/__init__.py
@@ -11,9 +11,9 @@ from ..Logger import logger
 from .. import CPU, RAM, Cartridge, BootROM, LCD, Interaction, Timer, CoreDump
 
 class Motherboard():
-    from MemoryManager import __getitem__, __setitem__, transferDMAtoOAM
-    from StateManager import saveState, loadState
-    from Coordinator import calculateCycles, setSTATMode, checkLYC, tickFrame
+    from .MemoryManager import __getitem__, __setitem__, transferDMAtoOAM
+    from .StateManager import saveState, loadState
+    from .Coordinator import calculateCycles, setSTATMode, checkLYC, tickFrame
     from ..CPU.flags import TIMER
 
     def __init__(self, gameROMFile, bootROMFile, window, profiling = False, debugger = None):

--- a/Source/PyBoy/ScreenRecorder.py
+++ b/Source/PyBoy/ScreenRecorder.py
@@ -2,7 +2,7 @@ import os
 import imageio
 import numpy as np
 import time
-from Logger import logger
+from PyBoy.Logger import logger
 
 
 class ScreenRecorder:

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -9,15 +9,15 @@
 import sys
 import time
 import numpy as np
-from ScreenRecorder import ScreenRecorder
+from PyBoy.ScreenRecorder import ScreenRecorder
 import platform
 
-from MB import Motherboard
-from WindowEvent import WindowEvent
-from Logger import logger, addConsoleHandler
-import BotSupport
-import Logger
-from OpcodeToName import CPU_COMMANDS, CPU_COMMANDS_EXT
+from .MB import Motherboard
+from .WindowEvent import WindowEvent
+from .Logger import logger, addConsoleHandler
+from . import BotSupport
+from . import Logger
+from .OpcodeToName import CPU_COMMANDS, CPU_COMMANDS_EXT
 
 
 SPF = 1/60. # inverse FPS (frame-per-second)
@@ -122,7 +122,7 @@ class PyBoy():
             argMax = np.argsort(self.mb.cpu.hitRate)
             for n in argMax[::-1]:
                 if self.mb.cpu.hitRate[n] != 0:
-                    print "%3x %16s %s" % (n, CPU_COMMANDS[n] if n<0x100 else CPU_COMMANDS_EXT[n-0x100], self.mb.cpu.hitRate[n])
+                    print("%3x %16s %s" % (n, CPU_COMMANDS[n] if n<0x100 else CPU_COMMANDS_EXT[n-0x100], self.mb.cpu.hitRate[n]))
 
 
     ###########################


### PR DESCRIPTION
PyPy3 doesn't actually work yet because marcusva/py-sdl2#132 is blocking upstream numpy, and numpypy doesn't work on python3. But once that issue is resolved, this should be most of what's needed for pypy3