### PR TITLE
Profile function calls, better argument parsing, and GameWindow decoupling

### DIFF
--- a/Source/PyBoy/CPU/__init__.py
+++ b/Source/PyBoy/CPU/__init__.py
@@ -9,7 +9,7 @@ from ..OpcodeToName import CPU_COMMANDS, CPU_COMMANDS_EXT
 from .flags import flagZ, flagN, flagH, flagC
 from ..Logger import logger
 from .Interrupts import InterruptVector, NoInterrupt
-import numpy as np
+
 
 class CPU(object): # 'object' is important for property!!!
     from .opcodes import opcodes

--- a/Source/PyBoy/CPU/__init__.py
+++ b/Source/PyBoy/CPU/__init__.py
@@ -33,7 +33,7 @@ class CPU(object): # 'object' is important for property!!!
     fNC = property(lambda s:not bool(s.F & (1 << flagC)), None)
     fNZ = property(lambda s:not bool(s.F & (1 << flagZ)), None)
 
-    def __init__(self, MB, profiling=False):
+    def __init__(self, MB):
         self.mb = MB
 
         self.interruptMasterEnable = False
@@ -53,12 +53,6 @@ class CPU(object): # 'object' is important for property!!!
         self.oldPC = -1
         self.lala = False
 
-        # Profiling
-        self.profiling = profiling
-        if profiling:
-            self.hitRate = np.zeros(shape=(512,), dtype=int)
-
-
     def executeInstruction(self, instruction):
         # '*' unpacks tuple into arguments
         success = instruction[0](*instruction[2])
@@ -76,12 +70,6 @@ class CPU(object): # 'object' is important for property!!!
             pc += 1
             opcode = self.mb[pc]
             opcode += 0x100  # Internally shifting look-up table
-
-        #Profiling
-        if self.profiling:
-            self.hitRate[opcode] += 1
-        # if opcode == 0xf0:
-        #     print "F0", hex(self.mb[pc+1])
 
         operation = opcodes.opcodes[opcode]
 

--- a/Source/PyBoy/CPU/generator.py
+++ b/Source/PyBoy/CPU/generator.py
@@ -21,14 +21,15 @@ warning = """\
 """
 
 # from registers import A, B, C, D, E, H, L, SP, PC
-# from flags import flagZ, flagN, flagH, flagC
 imports = """
 from .flags import flagZ, flagN, flagH, flagC
-from ..MathUint8 import getSignedInt8
-
 """
 
+def inlineGetSignedInt8(arg):
+    return "((({} + 128) & 255) - 128)".format(arg)
+
 opcodes = []
+
 
 class MyHTMLParser(HTMLParser):
     def __init__(self):
@@ -119,7 +120,7 @@ class Operand():
             self.signed = True
 
             # post operation set in LD handler!
-            return "self.SP + getSignedInt8(v)"
+            return "self.SP + " + inlineGetSignedInt8("v")
 
         elif operand[0] == '(' and operand[-1] == ')':
             self.pointer = True
@@ -147,7 +148,7 @@ class Operand():
             self.immediate = True
 
             if operand == 'r8':
-                code = "getSignedInt8(%s)" % code
+                code = inlineGetSignedInt8(code)
                 self.signed = True
 
             elif operand == 'a8':
@@ -764,7 +765,7 @@ class opcodeData():
         code = Code(fname(), self.opcode, self.name, right.immediate, self.length, branchOp = True)
         if left is None:
             code.addLines([
-                "self.PC += %d + getSignedInt8(v)" % self.length,
+                "self.PC += %d + " % self.length + inlineGetSignedInt8("v"),
                 "self.PC &= 0xFFFF",
                 "return 0"
             ])
@@ -772,7 +773,7 @@ class opcodeData():
             code.addLines([
                 "self.PC += %d" % self.length,
                 "if %s:" % left.code,
-                "\tself.PC += getSignedInt8(v)",
+                "\tself.PC += " + inlineGetSignedInt8("v"),
                 "\tself.PC &= 0xFFFF",
                 "\treturn 0",
                 "else:",
@@ -1103,4 +1104,3 @@ def load():
     update()
 
 load()
-

--- a/Source/PyBoy/CPU/opcodes.py
+++ b/Source/PyBoy/CPU/opcodes.py
@@ -4,8 +4,6 @@
 # CHANGES TO THE CODE SHOULD BE MADE IN 'generator.py'.
 
 from .flags import flagZ, flagN, flagH, flagC
-from ..MathUint8 import getSignedInt8
-
 def NOP_00(self): # 00 NOP
     self.PC += 1
     return 0
@@ -203,7 +201,7 @@ def RLA_17(self): # 17 RLA
     return 0
 
 def JR_18(self, v): # 18 JR r8
-    self.PC += 2 + getSignedInt8(v)
+    self.PC += 2 + (((v + 128) & 255) - 128)
     self.PC &= 0xFFFF
     return 0
 
@@ -275,7 +273,7 @@ def RRA_1f(self): # 1f RRA
 def JR_20(self, v): # 20 JR NZ,r8
     self.PC += 2
     if self.fNZ:
-        self.PC += getSignedInt8(v)
+        self.PC += (((v + 128) & 255) - 128)
         self.PC &= 0xFFFF
         return 0
     else:
@@ -354,7 +352,7 @@ def DAA_27(self): # 27 DAA
 def JR_28(self, v): # 28 JR Z,r8
     self.PC += 2
     if self.fZ:
-        self.PC += getSignedInt8(v)
+        self.PC += (((v + 128) & 255) - 128)
         self.PC &= 0xFFFF
         return 0
     else:
@@ -427,7 +425,7 @@ def CPL_2f(self): # 2f CPL
 def JR_30(self, v): # 30 JR NC,r8
     self.PC += 2
     if self.fNC:
-        self.PC += getSignedInt8(v)
+        self.PC += (((v + 128) & 255) - 128)
         self.PC &= 0xFFFF
         return 0
     else:
@@ -492,7 +490,7 @@ def SCF_37(self): # 37 SCF
 def JR_38(self, v): # 38 JR C,r8
     self.PC += 2
     if self.fC:
-        self.PC += getSignedInt8(v)
+        self.PC += (((v + 128) & 255) - 128)
         self.PC &= 0xFFFF
         return 0
     else:
@@ -1969,7 +1967,7 @@ def RST_e7(self): # e7 RST 20H
     return 0
 
 def ADD_e8(self, v): # e8 ADD SP,r8
-    t = self.SP+getSignedInt8(v)
+    t = self.SP+(((v + 128) & 255) - 128)
     flag = 0b00000000
     flag += (((self.SP & 0xF) + (v & 0xF)) > 0xF) << flagH
     flag += (((self.SP & 0xFF) + (v & 0xFF)) > 0xFF) << flagC
@@ -2057,7 +2055,7 @@ def RST_f7(self): # f7 RST 30H
     return 0
 
 def LD_f8(self, v): # f8 LD HL,SP+r8
-    self.HL = self.SP + getSignedInt8(v)
+    self.HL = self.SP + (((v + 128) & 255) - 128)
     t = self.HL
     flag = 0b00000000
     flag += (((self.SP & 0xF) + (v & 0xF)) > 0xF) << flagH

--- a/Source/PyBoy/GameWindow/GameWindow_Multiprocess.py
+++ b/Source/PyBoy/GameWindow/GameWindow_Multiprocess.py
@@ -4,10 +4,8 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
-import time
+
 import numpy as np
-import warnings
 
 import multiprocessing
 from multiprocessing import Process, Pipe, Queue

--- a/Source/PyBoy/GameWindow/GameWindow_OpenGL.py
+++ b/Source/PyBoy/GameWindow/GameWindow_OpenGL.py
@@ -4,7 +4,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
+
 import numpy as np
 
 from OpenGL.GL import *

--- a/Source/PyBoy/GameWindow/GameWindow_SDL2.py
+++ b/Source/PyBoy/GameWindow/GameWindow_SDL2.py
@@ -4,13 +4,11 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
-import time
+
 import ctypes
 import sdl2
 import sdl2.ext
 import numpy as np
-import warnings
 
 from .. import CoreDump
 from ..MathUint8 import getSignedInt8

--- a/Source/PyBoy/GameWindow/GameWindow_SDL2.py
+++ b/Source/PyBoy/GameWindow/GameWindow_SDL2.py
@@ -11,7 +11,6 @@ import sdl2.ext
 import numpy as np
 
 from .. import CoreDump
-from ..MathUint8 import getSignedInt8
 from ..WindowEvent import WindowEvent
 from ..GameWindow import AbstractGameWindow
 
@@ -214,7 +213,8 @@ class SdlGameWindow(AbstractGameWindow):
                     backgroundTileIndex = lcd.VRAM[backgroundViewAddress + (((xx + x)/8)%32 + ((y+yy)/8)*32)%0x400]
 
                     if lcd.LCDC.tile_select == 0: # If using signed tile indices
-                        backgroundTileIndex = getSignedInt8(backgroundTileIndex)+256
+                        # ((x + 128) & 255) - 128 to convert to signed, then add 256 for offset (reduces to + 128)
+                        backgroundTileIndex = ((backgroundTileIndex + 128) & 255) + 128
 
                     self._screenBuffer[y,x] = self.tile_cache[backgroundTileIndex*8 + (x+offset)%8, (y+yy)%8]
                 else:
@@ -227,7 +227,8 @@ class SdlGameWindow(AbstractGameWindow):
                         windowTileIndex = lcd.VRAM[windowViewAddress + (((x-wx)/8)%32 + ((y-wy)/8)*32)%0x400]
 
                         if lcd.LCDC.tile_select == 0: # If using signed tile indices
-                            windowTileIndex = getSignedInt8(windowTileIndex)+256
+                            # ((x + 128) & 255) - 128 to convert to signed, then add 256 for offset (reduces to + 128)
+                            windowTileIndex = ((windowTileIndex + 128) & 255) + 128
 
                         self._screenBuffer[y,x] = self.tile_cache[windowTileIndex*8 + (x-(wx))%8, (y-wy)%8]
 
@@ -364,7 +365,8 @@ class SdlGameWindow(AbstractGameWindow):
             # http://problemkaputt.de/pandocs.htm#lcdcontrolregister
             # BG & Window Tile Data Select   (0=8800-97FF, 1=8000-8FFF)
             if (lcd.LCDC.value >> 4) & 1 == 0: #TODO: use correct flag
-                tileIndex = 256 + getSignedInt8(tileIndex)
+                # ((x + 128) & 255) - 128 to convert to signed, then add 256 for offset (reduces to + 128)
+                tileIndex = ((tileIndex + 128) & 255) + 128
 
             tile_column = (n-0x1800)%winHorTileView1Limit # Horizontal tile number wrapping on 16
             tileRow = (n-0x1800)/winVerTileView1Limit # Vertical time number based on tileColumn
@@ -388,7 +390,8 @@ class SdlGameWindow(AbstractGameWindow):
             # http://problemkaputt.de/pandocs.htm#lcdcontrolregister
             # BG & Window Tile Data Select   (0=8800-97FF, 1=8000-8FFF)
             if (lcd.LCDC.value >> 4) & 1 == 0:
-                tileIndex = 256 + getSignedInt8(tileIndex)
+                # ((x + 128) & 255) - 128 to convert to signed, then add 256 for offset (reduces to + 128)
+                tileIndex = ((tileIndex + 128) & 255) + 128
 
             tile_column = (n-0x1C00)%winHorTileView2Limit # Horizontal tile number wrapping on 16
             tileRow = (n-0x1C00)/winVerTileView2Limit # Vertical time number based on tileColumn

--- a/Source/PyBoy/GameWindow/GameWindow_Scanline.py
+++ b/Source/PyBoy/GameWindow/GameWindow_Scanline.py
@@ -8,6 +8,7 @@
 # It's closer to the hardware and maybe easier to understand, but not
 # fast enough to replace GameWindow_SDL2
 
+import array
 import ctypes
 import sdl2
 import sdl2.ext
@@ -85,7 +86,8 @@ class ScanlineGameWindow(AbstractGameWindow):
                                                  sdl2.SDL_PIXELFORMAT_ARGB32,
                                                  sdl2.SDL_TEXTUREACCESS_STATIC,
                                                  *gameboyResolution)
-        self._linebuf = [0] * gameboyResolution[0]
+        self._linebuf = array.array('I', [0] * gameboyResolution[0])
+        self._linebuf_p = ctypes.c_void_p(self._linebuf.buffer_info()[0])
         self._linerect = sdl2.rect.SDL_Rect(0, 0, gameboyResolution[0], 1)
 
         self.ticks = sdl2.SDL_GetTicks()
@@ -238,10 +240,8 @@ class ScanlineGameWindow(AbstractGameWindow):
 
         # Copy into the screen buffer from the list
         self._linerect.y = y
-        buf, _ = sdl2.ext.array.to_ctypes(self._linebuf, ctypes.c_uint32,
-                                          gameboyResolution[0])
         sdl2.SDL_UpdateTexture(self._screenbuf, self._linerect,
-                               ctypes.byref(buf), gameboyResolution[0])
+                               self._linebuf_p, gameboyResolution[0])
 
     def renderScreen(self, lcd):
         # Copy from internal buffer to screen

--- a/Source/PyBoy/GameWindow/GameWindow_dummy.py
+++ b/Source/PyBoy/GameWindow/GameWindow_dummy.py
@@ -4,8 +4,6 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
-import time
 
 from .. import CoreDump
 from ..WindowEvent import WindowEvent

--- a/Source/PyBoy/GameWindow/__init__.py
+++ b/Source/PyBoy/GameWindow/__init__.py
@@ -7,25 +7,27 @@
 
 from ..Logger import logger
 from .AbstractGameWindow import AbstractGameWindow
-
-try:
-    from .GameWindow_SDL2 import SdlGameWindow
-except:
-    logger.warning("Failed to load SDL2 GameWindow.")
-
-try:
-    from .GameWindow_Scanline import ScanlineGameWindow
-except:
-    logger.warning("Failed to load Scanline GameWindow")
-
-try:
-    from .GameWindow_OpenGL import OpenGLGameWindow
-except:
-    logger.warning("Failed to load OpenGL GameWindow")
-
-try:
-    from .GameWindow_Multiprocess import MultiprocessGameWindow
-except:
-    logger.warning("Failed to load MultiProcess GameWindow")
-
 from .GameWindow_dummy import DummyGameWindow
+
+
+windowTypes = ["SDL2", "scanline", "dummy", "OpenGL", "Multiprocess"]
+defaultWindowType = "SDL2"
+
+
+def createGameWindow(windowType):
+    if windowType == "SDL2":
+        from .GameWindow_SDL2 import SdlGameWindow
+        return SdlGameWindow(scale=2)
+    elif windowType == "scanline":
+        from .GameWindow_Scanline import ScanlineGameWindow
+        return ScanlineGameWindow(scale=2)
+    elif windowType == "OpenGL":
+        from .GameWindow_OpenGL import OpenGLGameWindow
+        return OpenGLGameWindow(scale=2)
+    elif windowType == "Multiprocess":
+        from .GameWindow_Multiprocess import MultiprocessGameWindow
+        return MultiprocessGameWindow()
+    elif windowType == "dummy":
+        return DummyGameWindow()
+    else:
+        raise Exception("Invalid GameWindow type " + str(windowType))

--- a/Source/PyBoy/LCD.py
+++ b/Source/PyBoy/LCD.py
@@ -6,7 +6,7 @@
 
 from . import CoreDump
 from .RAM import allocateRAM, VIDEO_RAM, OBJECT_ATTRIBUTE_MEMORY
-import numpy as np
+
 
 LCDC, STAT, SCY, SCX, LY, LYC, DMA, BGPalette, OBP0, OBP1, WY, WX = range(0xFF40, 0xFF4C)
 

--- a/Source/PyBoy/MB/Coordinator.py
+++ b/Source/PyBoy/MB/Coordinator.py
@@ -43,10 +43,6 @@ def calculateCycles(self, x):
             # Serial is not implemented, so this isn't a concern
             cycles = min(self.timer.cyclesToInterrupt(), x)
 
-            # Profiling
-            if self.cpu.profiling:
-                self.cpu.hitRate[0x76] += cycles/4
-
         x -= cycles
         if self.timer.tick(cycles):
             self.cpu.setInterruptFlag(self.TIMER)

--- a/Source/PyBoy/MB/__init__.py
+++ b/Source/PyBoy/MB/__init__.py
@@ -4,10 +4,10 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
 
 from ..Logger import logger
 from .. import CPU, RAM, Cartridge, BootROM, LCD, Interaction, Timer, CoreDump
+
 
 class Motherboard():
     from .MemoryManager import __getitem__, __setitem__, transferDMAtoOAM
@@ -15,7 +15,8 @@ class Motherboard():
     from .Coordinator import calculateCycles, setSTATMode, checkLYC, tickFrame
     from ..CPU.flags import TIMER
 
-    def __init__(self, gameROMFile, bootROMFile, window, debugger = None):
+    def __init__(self, gameROMFile, bootROMFile, window, debugger=None,
+                 loadState=False):
         if bootROMFile is not None:
             logger.info("Boot-ROM file provided")
 
@@ -30,7 +31,7 @@ class Motherboard():
         self.lcd = LCD.LCD(self, window.color_palette)
         self.bootROMEnabled = True
 
-        if "loadState" in sys.argv:
+        if loadState:
             self.loadState(self.cartridge.filename+".state")
 
         self.cartridge.loadRAM()

--- a/Source/PyBoy/MB/__init__.py
+++ b/Source/PyBoy/MB/__init__.py
@@ -15,12 +15,9 @@ class Motherboard():
     from .Coordinator import calculateCycles, setSTATMode, checkLYC, tickFrame
     from ..CPU.flags import TIMER
 
-    def __init__(self, gameROMFile, bootROMFile, window, profiling = False, debugger = None):
+    def __init__(self, gameROMFile, bootROMFile, window, debugger = None):
         if bootROMFile is not None:
             logger.info("Boot-ROM file provided")
-
-        if profiling:
-            logger.info("Profiling enabled")
 
         self.debugger = debugger
         self.MainWindow = window
@@ -29,7 +26,7 @@ class Motherboard():
         self.cartridge = Cartridge.Cartridge(gameROMFile)
         self.bootROM = BootROM.BootROM(bootROMFile)
         self.ram = RAM.RAM(random=False)
-        self.cpu = CPU.CPU(self, profiling)
+        self.cpu = CPU.CPU(self)
         self.lcd = LCD.LCD(self, window.color_palette)
         self.bootROMEnabled = True
 

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -132,7 +132,7 @@ class PyBoy():
             self.profiler.disable()
             stats = pstats.Stats(self.profiler)
 
-            if "profilingFile" in self.kwargs:
+            if "profilingFile" in self.kwargs and self.kwargs["profilingFile"]:
                 try:
                     stats.dump_stats(self.kwargs["profilingFile"])
                 except IOError:

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -8,6 +8,7 @@
 
 import time
 import platform
+import cProfile
 import numpy as np
 
 import GameWindow
@@ -25,7 +26,13 @@ SPF = 1/60. # inverse FPS (frame-per-second)
 
 class PyBoy():
     def __init__(self, windowType, ROM, bootROM=None, debug=False,
-                 profiling=False, loadState=False):
+                 profile=False, loadState=False):
+
+        if profile:
+            self.profiler = cProfile.Profile()
+            self.profiler.enable()
+        else:
+            self.profiler = None
 
         self.debugger = None
         self.mb = None
@@ -37,9 +44,7 @@ class PyBoy():
         else:
             addConsoleHandler()
 
-        self.profiling = profiling
         self.mb = Motherboard(ROM, bootROM, self.window,
-                              profiling = self.profiling,
                               debugger = self.debugger)
 
         if not self.debugger is None:
@@ -120,13 +125,9 @@ class PyBoy():
         self.window.stop()
         self.mb.stop(save)
 
-        if self.profiling:
-            np.set_printoptions(threshold=np.inf)
-            argMax = np.argsort(self.mb.cpu.hitRate)
-            for n in argMax[::-1]:
-                if self.mb.cpu.hitRate[n] != 0:
-                    print("%3x %16s %s" % (n, CPU_COMMANDS[n] if n<0x100 else CPU_COMMANDS_EXT[n-0x100], self.mb.cpu.hitRate[n]))
-
+        if self.profiler:
+            self.profiler.disable()
+            self.profiler.print_stats(sort='cumulative')
 
     ###########################
     #

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -131,9 +131,18 @@ class PyBoy():
         if self.profiler:
             self.profiler.disable()
             stats = pstats.Stats(self.profiler)
+
+            if "profilingFile" in self.kwargs:
+                try:
+                    stats.dump_stats(self.kwargs["profilingFile"])
+                except IOError:
+                    logger.warn("Failed to save profiling data to" +
+                                self.kwargs["profilingFile"])
+
             stats.strip_dirs()
             if "profilingSort" in self.kwargs:
                 stats.sort_stats(self.kwargs["profilingSort"])
+
             if "profilingFilter" in self.kwargs:
                 restrictions = []
                 for r in self.kwargs["profilingFilter"]:

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -5,11 +5,13 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import sys
+
 import time
-import numpy as np
-from PyBoy.ScreenRecorder import ScreenRecorder
 import platform
+import numpy as np
+
+import GameWindow
+from PyBoy.ScreenRecorder import ScreenRecorder
 
 from .MB import Motherboard
 from .WindowEvent import WindowEvent
@@ -22,19 +24,23 @@ from .OpcodeToName import CPU_COMMANDS, CPU_COMMANDS_EXT
 SPF = 1/60. # inverse FPS (frame-per-second)
 
 class PyBoy():
-    def __init__(self, window, ROM, bootROM = None):
+    def __init__(self, windowType, ROM, bootROM=None, debug=False,
+                 profiling=False, loadState=False):
+
         self.debugger = None
         self.mb = None
-        self.window = window
+        self.window = GameWindow.createGameWindow(windowType)
 
-        if "debug" in sys.argv and platform.system() != "Windows":
+        if debug:
             self.debugger = Debug()
             self.debugger.tick()
         else:
             addConsoleHandler()
 
-        self.profiling = "profiling" in sys.argv
-        self.mb = Motherboard(ROM, bootROM, window, profiling = self.profiling, debugger = self.debugger)
+        self.profiling = profiling
+        self.mb = Motherboard(ROM, bootROM, self.window,
+                              profiling = self.profiling,
+                              debugger = self.debugger)
 
         if not self.debugger is None:
             self.debugger.mb = self.mb

--- a/Source/PyBoy/__init__.py
+++ b/Source/PyBoy/__init__.py
@@ -7,7 +7,6 @@
 
 
 import time
-import platform
 import cProfile
 import pstats
 

--- a/Source/main.py
+++ b/Source/main.py
@@ -55,7 +55,7 @@ def getROM(ROMdir):
 
     return filename
 
-if __name__ == "__main__":
+def main():
     # Automatically bump to '-OO' optimizations
     if __debug__:
         os.execl(sys.executable, sys.executable, '-OO', *sys.argv)
@@ -97,3 +97,10 @@ if __name__ == "__main__":
     #         logger.info("Debugger ready for shutdown")
     #         time.sleep(10)
     #         debugger.quit()
+
+
+if __name__ == "__main__":
+    main()
+
+    # import cProfile
+    # cProfile.run('main()', sort='cumulative')

--- a/Source/main.py
+++ b/Source/main.py
@@ -54,9 +54,8 @@ def parse_arguments(argstring=None):
                         "Choices: " + ", ".join(GameWindow.windowTypes))
     parser.add_argument("--debug", help="Enable debug mode",
                         action='store_true')
-    parser.add_argument("--profile", nargs='?', const=True,
-                        choices=[True, "opcodes"],
-                        help="Enable profiling, optional presets")
+    parser.add_argument("--profile", action="store_true",
+                        help="Enable profiling with cProfile, some overhead")
     parser.add_argument("--profilingFile", type=str,
                         help="Save file for profiling data")
     parser.add_argument("--profilingSort",

--- a/Source/main.py
+++ b/Source/main.py
@@ -7,11 +7,11 @@
 
 
 import argparse
-import traceback
-import time
 import os
-import sys
 import platform
+import sys
+import time
+import traceback
 from PyBoy import GameWindow
 from PyBoy.Logger import logger, addConsoleHandler
 
@@ -26,8 +26,8 @@ from PyBoy import PyBoy
 
 def getROM(ROMdir):
     # Give a list of ROMs to start
-    found_files = filter(lambda f: f.lower().endswith(
-        ".gb") or f.lower().endswith(".gbc"), os.listdir(ROMdir))
+    found_files = filter(lambda f: f.lower().endswith(".gb") or
+                         f.lower().endswith(".gbc"), os.listdir(ROMdir))
     for i, f in enumerate(found_files):
         print ("%s\t%s" % (i + 1, f))
     filename = raw_input("Write the name or number of the ROM file:\n")
@@ -52,7 +52,7 @@ def parse_arguments(argstring=None):
                         "Choices: " + ", ".join(GameWindow.windowTypes))
     parser.add_argument("--debug", help="Enable debug mode",
                         action='store_true')
-    parser.add_argument("--profiling", help="Enable profiling",
+    parser.add_argument("--profile", help="Enable profiling",
                         action="store_true")
     parser.add_argument("--loadState", help="Load state from .state file",
                         action="store_true")
@@ -60,7 +60,7 @@ def parse_arguments(argstring=None):
     return vars(parser.parse_args())
 
 
-def main(romfile=None, window=None, debug=False, profiling=False,
+def main(romfile=None, window=None, debug=False, profile=False,
          loadState=False):
 
     # Automatically bump to '-OO' optimizations
@@ -87,7 +87,8 @@ def main(romfile=None, window=None, debug=False, profiling=False,
     
     try:
         # Start PyBoy and run loop
-        pyboy = PyBoy(window, romfile, bootROM)
+        pyboy = PyBoy(window, romfile, bootROM, debug=debug, profile=profile,
+                      loadState=loadState)
         while not pyboy.tick():
             pass
         pyboy.stop()
@@ -107,6 +108,3 @@ def main(romfile=None, window=None, debug=False, profiling=False,
 if __name__ == "__main__":
     arguments = parse_arguments()
     main(**arguments)
-
-    #import cProfile
-    #cProfile.run('main()', sort='cumulative')

--- a/Source/main.py
+++ b/Source/main.py
@@ -57,8 +57,8 @@ def parse_arguments(argstring=None):
     parser.add_argument("--profile", nargs='?', const=True,
                         choices=[True, "opcodes"],
                         help="Enable profiling, optional presets")
-    # parser.add_argument("--profilingFile", type=str,
-    #                     help="Save file for profiling data")
+    parser.add_argument("--profilingFile", type=str,
+                        help="Save file for profiling data")
     parser.add_argument("--profilingSort",
                         help="Sort order for profiling data",
                         choices=["ncalls", "cumulative", "file", "line",

--- a/Source/main.py
+++ b/Source/main.py
@@ -12,6 +12,8 @@ import platform
 import sys
 import time
 import traceback
+from pstats import Stats
+
 from PyBoy import GameWindow
 from PyBoy.Logger import logger, addConsoleHandler
 
@@ -52,16 +54,24 @@ def parse_arguments(argstring=None):
                         "Choices: " + ", ".join(GameWindow.windowTypes))
     parser.add_argument("--debug", help="Enable debug mode",
                         action='store_true')
-    parser.add_argument("--profile", help="Enable profiling",
-                        action="store_true")
+    parser.add_argument("--profile", nargs='?', const=True,
+                        choices=[True, "opcodes"],
+                        help="Enable profiling, optional presets")
+    # parser.add_argument("--profilingFile", type=str,
+    #                     help="Save file for profiling data")
+    parser.add_argument("--profilingSort",
+                        help="Sort order for profiling data",
+                        choices=["ncalls", "cumulative", "file", "line",
+                                 "name", "nfl", "pcalls", "stdname", "time"])
+    parser.add_argument("--profilingFilter", nargs='+',
+                        help="Filter(s) for profiling data")
     parser.add_argument("--loadState", help="Load state from .state file",
                         action="store_true")
 
     return vars(parser.parse_args())
 
 
-def main(romfile=None, window=None, debug=False, profile=False,
-         loadState=False):
+def main(romfile=None, window=None, **kwargs):
 
     # Automatically bump to '-OO' optimizations
     if __debug__:
@@ -87,8 +97,7 @@ def main(romfile=None, window=None, debug=False, profile=False,
     
     try:
         # Start PyBoy and run loop
-        pyboy = PyBoy(window, romfile, bootROM, debug=debug, profile=profile,
-                      loadState=loadState)
+        pyboy = PyBoy(window, romfile, bootROM, **kwargs)
         while not pyboy.tick():
             pass
         pyboy.stop()


### PR DESCRIPTION
This branch introduces profiling with cProfile. All function timings are tracked and reported, with some small overhead. In the course of implementing this, I also moved things around in `main.py`, using `argparse` to process command line arguments and removing references to `sys.argv` throughout the code. I also redid GameWindow selection and moved the functionality to `GameWindow/__init__.py`. The resulting code is cleaner in places, though some of the profiling code is a bit sprawling, and probably should be moved to its own class eventually. 

For now, though, maybe see if the functionality is good and if the argparse stuff looks okay. It will be better for running PyBoy as an API through other scripts to remove the direct `sys.argv` access.

The profiling code already helped me find an inefficiency in `GameWindow_Scanline.py`, and the fix for that is included here. Scanline is much faster now--almost as fast as SDL2.