### PR TITLE
Cython Scanline window implementation

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -19,6 +19,7 @@ clean:
 	find . -name "*.c" -delete
 	find . -name "*.h" -delete
 	find . -name "*.html" -delete
+	find . -name "__pycache__" -d -delete
 
 run: build
 	${PY} main.py SDL2 ROMs/POKEMON\ BLUE.gb

--- a/Source/PyBoy/MB/MB.py
+++ b/Source/PyBoy/MB/MB.py
@@ -238,8 +238,8 @@ class Motherboard():
 
     def setitem(self,i,value):
         if i == 0xFF01:
-            print (chr(value)),
-        assert value < 0x100, "Memory write error! Can't write %s to %s" % (hex(value),hex(i))
+            print ("write to 0xFF01:", hex(value))
+            assert value < 0x100, "Memory write error! Can't write %s to %s" % (hex(value),hex(i))
 
         if 0x0000 <= i < 0x4000:  # 16kB ROM bank #0
             self.cartridge.setitem(i, value) #Doesn't change the data. This is for MBC commands

--- a/Source/PyBoy/MB/MB.py
+++ b/Source/PyBoy/MB/MB.py
@@ -238,7 +238,7 @@ class Motherboard():
 
     def setitem(self,i,value):
         if i == 0xFF01:
-            print ("write to 0xFF01:", hex(value))
+            print (chr(value)),
         assert value < 0x100, "Memory write error! Can't write %s to %s" % (hex(value),hex(i))
 
         if 0x0000 <= i < 0x4000:  # 16kB ROM bank #0

--- a/Source/PyBoy/MB/MB.py
+++ b/Source/PyBoy/MB/MB.py
@@ -239,7 +239,7 @@ class Motherboard():
     def setitem(self,i,value):
         if i == 0xFF01:
             print ("write to 0xFF01:", hex(value))
-            assert value < 0x100, "Memory write error! Can't write %s to %s" % (hex(value),hex(i))
+        assert value < 0x100, "Memory write error! Can't write %s to %s" % (hex(value),hex(i))
 
         if 0x0000 <= i < 0x4000:  # 16kB ROM bank #0
             self.cartridge.setitem(i, value) #Doesn't change the data. This is for MBC commands

--- a/Source/PyBoy/Window/Window_Scanline.pxd
+++ b/Source/PyBoy/Window/Window_Scanline.pxd
@@ -22,7 +22,6 @@ cdef dict windowEventsUp
 
 cdef class ScanlineWindow(GenericWindow):
 
-
     cdef sdl2.SDL_Window* _window
     cdef sdl2.SDL_Renderer* _sdlrenderer
     cdef sdl2.SDL_Texture* _screenbuf

--- a/Source/PyBoy/Window/Window_Scanline.pxd
+++ b/Source/PyBoy/Window/Window_Scanline.pxd
@@ -50,18 +50,26 @@ cdef class ScanlineWindow(GenericWindow):
         bgp=uint32_t[4],
         obp0 = uint32_t[4],
         obp1 = uint32_t[4],
-        tile=int,
-        x=int,
-        dx=int,
-        byte0=uint8_t,
-        byte1=uint8_t,
-        pixel=int,
+        bt=int,
+        wt=int,
+        sprites=int[10],
         nsprites=int,
+        ymin=int,
+        ymax=int,
+        x=int,
         n=int,
+        sx=int,
         sy=int,  # These maybe should be uint8_t, since they're
-        sx=int,  # getting unpacked from an array of bytes, but then
+        st=int,  # getting unpacked from an array of bytes, but then
         sf=int,  # the operations would have to be overflow safe.
         dy=int,
+        dx=int,
+        bbyte0=uint8_t,
+        bbyte1=uint8_t,
+        sbyte0=uint8_t,
+        sbyte1=uint8_t,
+        bpixel=int,
+        spixel=int
         )
     cdef void scanline(self, int, LCD)
 

--- a/Source/PyBoy/Window/Window_Scanline.pxd
+++ b/Source/PyBoy/Window/Window_Scanline.pxd
@@ -1,0 +1,73 @@
+# -*- encoding: utf-8 -*-
+#
+# License: See LICENSE file
+# GitHub: https://github.com/Baekalfen/PyBoy
+#
+
+
+cimport cython
+
+from libc.stdint cimport uint8_t, uint16_t, uint32_t
+
+cimport SDL2 as sdl2
+from PyBoy.LCD cimport LCD
+from PyBoy.Window.GenericWindow cimport GenericWindow
+
+
+# cdef unsigned char bytes2bits(unsigned char, unsigned char, unsigned char)
+
+cdef (int, int) gameboyResolution
+
+cdef class ScanlineWindow():
+
+    cdef dict windowEventsDown
+    cdef dict windowEventsUp
+    cdef uint32_t[4] palette
+
+    cdef sdl2.SDL_Window* _window
+    # cdef object _renderer
+    cdef sdl2.SDL_Renderer* _sdlrenderer
+    cdef sdl2.SDL_Texture* _screenbuf
+    cdef uint32_t[144] _linebuf
+    cdef uint32_t* _linebuf_p
+    cdef sdl2.SDL_Rect _linerect
+    cdef uint32_t ticks
+
+    # @cython.profile(False)
+    # @cython.locals(now=cython.uint32_t)
+    # cdef void framelimiter(self, int)
+
+    @cython.locals(
+        bOffset=int,
+        wOffset=int,
+        bx=int,
+        by=int,
+        wx=int,
+        wy=int,
+        bdy=int,
+        wdy=int,
+        tile_select=bint,
+        window_enabled_and_y=bint,
+        bgp=uint32_t[4],
+        tile=int,
+        x=int,
+        dx=int,
+        byte0=uint8_t,
+        byte1=uint8_t,
+        pixel=uint32_t,
+        nsprites=int,
+        n=int,
+        sy=int,  # These maybe should be uint8_t, since they're
+        sx=int,  # getting unpacked from an array of bytes, but then
+        sf=int,  # the operations would have to be overflow safe.
+        dy=int,
+        )
+    cdef void scanline(self, int, LCD)
+
+    cdef inline void renderScreen(self, LCD):
+        sdl2.SDL_RenderCopy(
+                self._sdlrenderer,
+                self._screenbuf,
+                NULL,
+                NULL)
+        sdl2.SDL_RenderPresent(self._sdlrenderer)

--- a/Source/PyBoy/Window/Window_Scanline.py
+++ b/Source/PyBoy/Window/Window_Scanline.py
@@ -4,74 +4,53 @@
 # GitHub: https://github.com/krs013/PyBoy
 #
 
-# Cacheless Window that renders screen line-by-line in scanline()
-# It's closer to the hardware and maybe easier to understand, but not
-# fast enough to replace Window_SDL2
-
 import array
-import ctypes
-import sdl2
 import sdl2.ext
-import sdl2.ext.colorpalettes
 
-from ..WindowEvent import WindowEvent
-from GenericWindow import GenericWindow
+from PyBoy import WindowEvent
+from PyBoy.Window.GenericWindow import GenericWindow
 
-from ..Logger import logger
 
 gameboyResolution = (160, 144)
 
-# Bit conversion for tiles using a lookup table
-# TODO: profile this vs just looping for the conversion
-# This creates a zip and generator object, so it may be slow
-lookup2bits = {b: tuple(b >> 2*s & 0x3 for s in reversed(range(4)))
-               for b in range(256)}
-def bytes2bits(byte0, byte1):
-    bits7531 = lookup2bits[0b10101010 & byte1 | 0b01010101 & byte0 >> 1]
-    bits6420 = lookup2bits[0b10101010 & byte1 << 1 | 0b01010101 & byte0]
-    for odd, even in zip(bits7531, bits6420):
-        yield odd
-        yield even
+windowEventsDown = {
+    sdl2.SDLK_UP        : WindowEvent.PressArrowUp,
+    sdl2.SDLK_DOWN      : WindowEvent.PressArrowDown,
+    sdl2.SDLK_RIGHT     : WindowEvent.PressArrowRight,
+    sdl2.SDLK_LEFT      : WindowEvent.PressArrowLeft,
+    sdl2.SDLK_a         : WindowEvent.PressButtonA,
+    sdl2.SDLK_s         : WindowEvent.PressButtonB,
+    sdl2.SDLK_RETURN    : WindowEvent.PressButtonStart,
+    sdl2.SDLK_BACKSPACE : WindowEvent.PressButtonSelect,
+    sdl2.SDLK_ESCAPE    : WindowEvent.Quit,
+    sdl2.SDLK_d         : WindowEvent.DebugToggle,
+    sdl2.SDLK_SPACE     : WindowEvent.PressSpeedUp,
+    sdl2.SDLK_i         : WindowEvent.ScreenRecordingToggle,
+}
+windowEventsUp = {
+    sdl2.SDLK_UP        : WindowEvent.ReleaseArrowUp,
+    sdl2.SDLK_DOWN      : WindowEvent.ReleaseArrowDown,
+    sdl2.SDLK_RIGHT     : WindowEvent.ReleaseArrowRight,
+    sdl2.SDLK_LEFT      : WindowEvent.ReleaseArrowLeft,
+    sdl2.SDLK_a         : WindowEvent.ReleaseButtonA,
+    sdl2.SDLK_s         : WindowEvent.ReleaseButtonB,
+    sdl2.SDLK_RETURN    : WindowEvent.ReleaseButtonStart,
+    sdl2.SDLK_BACKSPACE : WindowEvent.ReleaseButtonSelect,
+    sdl2.SDLK_z         : WindowEvent.SaveState,
+    sdl2.SDLK_x         : WindowEvent.LoadState,
+    sdl2.SDLK_SPACE     : WindowEvent.ReleaseSpeedUp,
+}
 
-class ScanlineWindow():
 
-    windowEventsDown = {
-        sdl2.SDLK_UP        : WindowEvent.PressArrowUp,
-        sdl2.SDLK_DOWN      : WindowEvent.PressArrowDown,
-        sdl2.SDLK_RIGHT     : WindowEvent.PressArrowRight,
-        sdl2.SDLK_LEFT      : WindowEvent.PressArrowLeft,
-        sdl2.SDLK_a         : WindowEvent.PressButtonA,
-        sdl2.SDLK_s         : WindowEvent.PressButtonB,
-        sdl2.SDLK_RETURN    : WindowEvent.PressButtonStart,
-        sdl2.SDLK_BACKSPACE : WindowEvent.PressButtonSelect,
-        sdl2.SDLK_ESCAPE    : WindowEvent.Quit,
-        sdl2.SDLK_d         : WindowEvent.DebugToggle,
-        sdl2.SDLK_SPACE     : WindowEvent.PressSpeedUp,
-        sdl2.SDLK_i         : WindowEvent.ScreenRecordingToggle,
-    }
-    windowEventsUp = {
-        sdl2.SDLK_UP        : WindowEvent.ReleaseArrowUp,
-        sdl2.SDLK_DOWN      : WindowEvent.ReleaseArrowDown,
-        sdl2.SDLK_RIGHT     : WindowEvent.ReleaseArrowRight,
-        sdl2.SDLK_LEFT      : WindowEvent.ReleaseArrowLeft,
-        sdl2.SDLK_a         : WindowEvent.ReleaseButtonA,
-        sdl2.SDLK_s         : WindowEvent.ReleaseButtonB,
-        sdl2.SDLK_RETURN    : WindowEvent.ReleaseButtonStart,
-        sdl2.SDLK_BACKSPACE : WindowEvent.ReleaseButtonSelect,
-        sdl2.SDLK_z         : WindowEvent.SaveState,
-        sdl2.SDLK_x         : WindowEvent.LoadState,
-        sdl2.SDLK_SPACE     : WindowEvent.ReleaseSpeedUp,
-    }
-
-    palette = (0x00000000, 0x00555555, 0x00aaaaaa, 0x00ffffff)
+class ScanlineWindow(GenericWindow):
 
     def __init__(self, scale=1):
+        GenericWindow.__init__(self, scale)
+
         self._linebuf = array.array('I', [0] * gameboyResolution[0])
-        self._linebuf_p = self._linebuf.buffer_info()[0]
-        self._linerect = (0, 0, gameboyResolution[0], 1)
+        self._linerect = {'x': 0, 'y': 0, 'w': gameboyResolution[0], 'h': 1}
 
     def init(self):
-
         sdl2.SDL_Init(sdl2.SDL_INIT_EVERYTHING)
         self.ticks = sdl2.SDL_GetTicks()
 
@@ -79,27 +58,27 @@ class ScanlineWindow():
             b"PyBoy",
             sdl2.SDL_WINDOWPOS_CENTERED,
             sdl2.SDL_WINDOWPOS_CENTERED,
-            scale*gameboyResolution[0],
-            scale*gameboyResolution[1],
+            self._scaledResolution[0],
+            self._scaledResolution[1],
             sdl2.SDL_WINDOW_RESIZABLE)
 
-        self._sdlrenderer = self.SDL_CreateRenderer(
+        self._sdlrenderer = sdl2.SDL_CreateRenderer(
             self._window, -1, sdl2.SDL_RENDERER_ACCELERATED)
 
         self._screenbuf = sdl2.SDL_CreateTexture(
             self._sdlrenderer,
-            sdl2.SDL_PIXELFORMAT_ARGB32,
+            sdl2.SDL_PIXELFORMAT_BGRA32,
             sdl2.SDL_TEXTUREACCESS_STREAMING,
             gameboyResolution[0], gameboyResolution[1])
 
         self.blankScreen()
-        self.SDL_ShowWindow(self._window)
+        sdl2.SDL_ShowWindow(self._window)
 
     def dump(self, filename):
         raise NotImplementedError()
 
     def setTitle(self, title):
-        self._window.title = title
+        sdl2.SDL_SetWindowTitle(self._window, title.encode())
 
     def getEvents(self):
         events = []
@@ -108,24 +87,26 @@ class ScanlineWindow():
             if event.type == sdl2.SDL_QUIT:
                 events.append(WindowEvent.Quit)
             elif event.type == sdl2.SDL_KEYDOWN:
-                events.append(self.windowEventsDown.get(event.key.keysym.sym, None))
+                events.append(windowEventsDown.get(event.key.keysym.sym, None))
             elif event.type == sdl2.SDL_KEYUP:
-                events.append(self.windowEventsUp.get(event.key.keysym.sym, None))
+                events.append(windowEventsUp.get(event.key.keysym.sym, None))
 
         return events
 
     def updateDisplay(self):
-        self._renderer.present()
-        pass
+        self._renderPresent()
 
-    def frameLimiter(self):
+    def framelimiter(self, speed):
         now = sdl2.SDL_GetTicks()
-        sdl2.SDL_Delay(max(0, int(1/60.0*1000-(now-self.ticks))))
+        delay = int(1/(60.0 * speed)*1000-(now-self.ticks))
+        if delay < 0: # Cython doesn't suppport max()
+            delay = 0
+        sdl2.SDL_Delay(delay)
         self.ticks = sdl2.SDL_GetTicks()
 
     def stop(self):
-        sdl2.SDL_DestroyWindow(self._window.window)
-        sdl2.ext.quit()
+        sdl2.SDL_DestroyWindow(self._window)
+        sdl2.SDL_Quit()
 
     def scanline(self, y, lcd):
         # Instead of recording parameters and rendering at vblank, we
@@ -134,11 +115,11 @@ class ScanlineWindow():
         # renderScreen
 
         # Background and Window View Address (offset into VRAM...)
-        bOffset = 0x1C00 if lcd.LCDC.background_map_select else 0x1800
-        wOffset = 0x1C00 if lcd.LCDC.window_map_select else 0x1800
+        bOffset = 0x1C00 if lcd.LCDC.backgroundMapSelect else 0x1800
+        wOffset = 0x1C00 if lcd.LCDC.windowMapSelect else 0x1800
 
-        bx, by = lcd.get_view_port()
-        wx, wy = lcd.get_window_pos()
+        bx, by = lcd.getViewPort()
+        wx, wy = lcd.getWindowPos()
 
         bdy = (y + by) % 8
         wdy = (y - wy) % 8
@@ -148,9 +129,8 @@ class ScanlineWindow():
         wOffset += ((y - wy) / 8 ) * 32
 
         # Dict lookups cost, so do some quick caching
-        tile_select = lcd.LCDC.tile_select == 0
-        window_enabled_and_y = lcd.LCDC.window_enabled and wy <= y
-        bgp = [self.palette[lcd.BGP.get_code(x)] for x in range(4)]
+        tile_select = lcd.LCDC.tileSelect == 0
+        window_enabled_and_y = lcd.LCDC.windowEnabled and wy <= y
 
         # Set to an impossible value to signal first loop. This could
         # break if we switch to an actual signed offset from a
@@ -173,7 +153,7 @@ class ScanlineWindow():
                     byte0 = lcd.VRAM[16 * tile + 2 * wdy]
                     byte1 = lcd.VRAM[16 * tile + 2 * wdy + 1]
 
-            elif lcd.LCDC.background_enable:
+            elif lcd.LCDC.backgroundEnable:
                 dx = (x + bx) % 8
                 if dx == 0 or tile < 0:
                     tile = lcd.VRAM[bOffset + (((x + bx) / 8) % 32)]
@@ -187,11 +167,11 @@ class ScanlineWindow():
                     byte1 = lcd.VRAM[16 * tile + 2 * bdy + 1]
 
             else:  # White if blank
-                self._linebuf[x] = self.palette[0]
+                self._linebuf[x] = self.colorPalette[0]
                 continue
 
             pixel = 2 * (byte1 & 0x80 >> dx) + (byte0 & 0x80 >> dx)
-            self._linebuf[x] = bgp[pixel >> 7-dx]
+            self._linebuf[x] = lcd.BGP.getColor(pixel >> 7-dx)
 
         # Limit to 10 sprites per line, could optionally disable later
         nsprites = 10
@@ -203,57 +183,68 @@ class ScanlineWindow():
 
         # Iterate through the sprites and update the buffer
         for n in range(0x00, 0xA0, 4):
-            sy, sx, tile, sf = lcd.OAM[n:n+4]
-
-            # Check if this is our line
-            if sy - 16 <= y < sy and 0 < sx < 168:
-                nsprites -= 1
-                if nsprites == 0:
-                    break
-            else:
-                continue
+            sy = lcd.OAM[n]
+            sx = lcd.OAM[n+1]
+            tile = lcd.OAM[n+2]
+            sf = lcd.OAM[n+3]
 
             # Get the row of the sprite, accounting for flipping
             dy = sy - y - 1 if sf & 0x40 else y - sy + 16
 
-            if lcd.LCDC.sprite_size:
+            if lcd.LCDC.spriteSize:
+                # Check if this is our line
+                if sy - 16 <= y < sy and 0 < sx < 168:
+                    nsprites -= 1
+                    if nsprites == 0:
+                        break
+                else:
+                    continue
+
                 # Double sprites start on an even index
                 tile &= 0xFE
             else:
+                # Check if this is our line
+                if sy - 16 <= y < sy - 8 and 0 < sx < 168:
+                    nsprites -= 1
+                    if nsprites == 0:
+                        break
+                else:
+                    continue
+
                 # Single sprites have y index from 0-7
                 dy &= 0x07
 
-            # Combine bytes into generator of 2-bit pixels
-            pixels = bytes2bits(*lcd.VRAM[16 * tile + 2 * dy:
-                                          16 * tile + 2 * dy + 2])
+            byte0 = lcd.VRAM[16 * tile + 2 * dy]
+            byte1 = lcd.VRAM[16 * tile + 2 * dy + 1]
 
-            # Flip if needed
-            if sf & 0x20:
-                pixels = reversed(tuple(pixels))
+            for dx in range(8):
+                x = sx - dx if sf & 0x20 else sx - 8 + dx
+                pixel = 2 * (byte1 & 0x80 >> dx) + (byte0 & 0x80 >> dx)
 
-            # Get the palette
-            if sf & 0x10:
-                obp = [self.palette[lcd.OBP1.get_code(x)] for x in range(4)]
-            else:
-                obp = [self.palette[lcd.OBP0.get_code(x)] for x in range(4)]
-
-            for x, pixel in zip(range(sx - 8, sx), pixels):
                 if 0 <= x < gameboyResolution[0]:
-                    if pixel and (not sf & 0x80 or self._linebuf[x] == bgp[0]):
-                        self._linebuf[x] = obp[pixel]
+                    if pixel and (not sf & 0x80 or
+                                  self._linebuf[x] == lcd.BGP.getColor(0)):
+                        if sf & 0x10:
+                            self._linebuf[x] = lcd.OBP1.getColor(pixel >> 7-dx)
+                        else:
+                            self._linebuf[x] = lcd.OBP0.getColor(pixel >> 7-dx)
 
         # Copy into the screen buffer from the list
         self._linerect.y = y
-        sdl2.SDL_UpdateTexture(self._screenbuf, self._linerect,
-                               self._linebuf_p, gameboyResolution[0])
 
-    # def renderScreen(self, lcd):
+        self._scanlineCopy()
+        # sdl2.SDL_UpdateTexture(self._screenbuf, self._linerect,
+        #                        self._linebuf_p, gameboyResolution[0])
+
+    def renderScreen(self, lcd):
         # Copy from internal buffer to screen
         # sdl2.render.SDL_RenderCopy(self._sdlrenderer, self._screenbuf, None, None)
+        self._renderCopy()
 
     def blankScreen(self):
         # Make the screen white
-        self._renderer.clear(self.palette[0])
+        sdl2.SDL_SetRenderDrawColor(self._sdlrenderer, 0xff, 0xff, 0xff, 0xff)
+        sdl2.SDL_RenderClear(self._sdlrenderer)
 
     def getScreenBuffer(self):
         # I think that calling get_surface() on the window breaks the

--- a/Source/PyBoy/Window/Window_Scanline.py
+++ b/Source/PyBoy/Window/Window_Scanline.py
@@ -230,15 +230,21 @@ class ScanlineWindow(GenericWindow):
                     dx = sx - x - 1 if sf & 0x20 else x - sx + 8
                     spixel = 2 * (sbyte1 & 0x80 >> dx) + (sbyte0 & 0x80 >> dx)
                     spixel >>= 7 - dx
-                    break
-            else:
-                spixel = 0
 
-            if spixel and (not sf & 0x80 or bpixel == 0):
-                if sf & 0x10:
-                    self._linebuf[x] = lcd.OBP1.getColor(spixel)
-                else:
-                    self._linebuf[x] = lcd.OBP0.getColor(spixel)
+                    # If the sprite is transparent, check for more
+                    if spixel == 0:
+                        continue
+
+                    # Draw the highest priority sprite pixel
+                    if not sf & 0x80 or bpixel == 0:
+                        if sf & 0x10:
+                            self._linebuf[x] = lcd.OBP1.getColor(spixel)
+                        else:
+                            self._linebuf[x] = lcd.OBP0.getColor(spixel)
+                    else:
+                        self._linebuf[x] = lcd.BGP.getColor(bpixel)
+
+                    break
             else:
                 self._linebuf[x] = lcd.BGP.getColor(bpixel)
 


### PR DESCRIPTION
Fixes #68 

Also contains a possible solution to #67, but it might not be clean enough, so take a look. All the code is contained in `Window_Scanline.py` and `Window_Scanline.pxd` 

This version has a slightly different approach to sprites to implement a [rule](http://gbdev.gg8.se/wiki/articles/Video_Display#Sprite_Priorities_and_Conflicts) that I hadn't read before. This version should be more correct but might be a little slower. It's still pretty quick under Cython, of course, but it doesn't beat the default window.