### PR TITLE
Cartridge cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .Python
 env/
 build/
+cython_debug/
 develop-eggs/
 dist/
 downloads/

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -22,7 +22,7 @@ clean:
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.c" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.h" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.html" -delete
-	find ${ROOT_DIR}/Source/pyboy/ -name "__pycache__" -d -delete
+	find ${ROOT_DIR}/Source/pyboy/ -name "__pycache__" -delete
 	rm -rf ${ROOT_DIR}/Source/build
 	rm -rf ${ROOT_DIR}/Source/dist
 	rm -rf ${ROOT_DIR}/Source/PyBoy.egg-info
@@ -50,4 +50,3 @@ docs: clean
 	cp html/pyboy/pyboy.html ${ROOT_DIR}/docs/
 	cp -r html/pyboy/botsupport ${ROOT_DIR}/docs/
 	rm -rf html
-

--- a/Source/main.py
+++ b/Source/main.py
@@ -56,10 +56,6 @@ def getROM(romdir):
 
 
 def main():
-    # Automatically bump to '-OO' optimizations
-    if __debug__:
-        os.execl(sys.executable, sys.executable, '-OO', *sys.argv)
-
     bootrom = "ROMs/DMG_ROM.bin"
     romdir = "ROMs/"
     scale = 3

--- a/Source/pyboy/core/cartridge/__init__.py
+++ b/Source/pyboy/core/cartridge/__init__.py
@@ -4,7 +4,7 @@
 #
 
 from .base_mbc import BaseMBC, ROMOnly
-from .cartridge import Cartridge
+from .cartridge import load_cartridge
 from .mbc1 import MBC1
 from .mbc2 import MBC2
 from .mbc3 import MBC3

--- a/Source/pyboy/core/cartridge/base_mbc.pxd
+++ b/Source/pyboy/core/cartridge/base_mbc.pxd
@@ -9,7 +9,7 @@ from libc.stdint cimport uint8_t, uint32_t
 cdef class BaseMBC:
     cdef unicode filename
     cdef unicode gamename
-    cdef uint8_t[:,:] rombanks
+    cdef uint8_t[:, :] rombanks
     # 16 is absoulte max. 8KB in each bank
     cdef uint8_t[16][8 * 1024] rambanks
     cdef unsigned char carttype

--- a/Source/pyboy/core/cartridge/base_mbc.pxd
+++ b/Source/pyboy/core/cartridge/base_mbc.pxd
@@ -9,8 +9,7 @@ from libc.stdint cimport uint8_t, uint32_t
 cdef class BaseMBC:
     cdef unicode filename
     cdef unicode gamename
-    # 256 is absoulte max. 16KB in each bank
-    cdef uint8_t[256][16 * 1024] rombanks
+    cdef uint8_t[:,:] rombanks
     # 16 is absoulte max. 8KB in each bank
     cdef uint8_t[16][8 * 1024] rambanks
     cdef unsigned char carttype
@@ -29,7 +28,7 @@ cdef class BaseMBC:
     cdef void save_ram(self, file)
     cdef void load_ram(self, file)
     cdef void init_rambanks(self, unsigned char)
-    cdef unicode getgamename(self, list)
+    cdef unicode getgamename(self, uint8_t[:,:])
 
     cdef unsigned char getitem(self, unsigned short)
     cdef void setitem(self, unsigned short, unsigned char)

--- a/Source/pyboy/core/cartridge/base_mbc.py
+++ b/Source/pyboy/core/cartridge/base_mbc.py
@@ -14,10 +14,7 @@ from .rtc import RTC
 class BaseMBC:
     def __init__(self, filename, rombanks, external_ram_count, carttype, sram, battery, rtc_enabled):
         self.filename = filename + ".ram"
-        banks = len(rombanks)
-        self.rombanks = [[0] * (16*1024) for _ in range(256)]
-        for n in range(banks):
-            self.rombanks[n][:] = rombanks[n]
+        self.rombanks = rombanks
         self.carttype = carttype
 
         self.battery = battery

--- a/Source/pyboy/core/cartridge/cartridge.pxd
+++ b/Source/pyboy/core/cartridge/cartridge.pxd
@@ -12,7 +12,7 @@ import cython
 from libc.stdint cimport uint8_t, uint16_t, uint32_t
 
 
-cpdef BaseMBC Cartridge(unicode)
+cpdef BaseMBC load_cartridge(unicode)
 cdef bint validate_checksum(uint8_t[:,:])
 
 @cython.locals(romdata=array, banksize=int)

--- a/Source/pyboy/core/cartridge/cartridge.pxd
+++ b/Source/pyboy/core/cartridge/cartridge.pxd
@@ -5,10 +5,18 @@
 
 from .base_mbc cimport BaseMBC
 
+from cpython.array cimport array
+from array import array
+
+import cython
+from libc.stdint cimport uint8_t, uint16_t, uint32_t
+
 
 cdef BaseMBC Cartridge(unicode)
-cdef bint validate_checksum(unsigned char[:,:])
-cdef unsigned char[:, :] load_romfile(unicode)
+cdef bint validate_checksum(uint8_t[:,:])
+
+@cython.locals(romdata=array, banksize=int)
+cdef uint8_t[:, :] load_romfile(unicode)
 
 cdef dict CARTRIDGE_TABLE
 cdef dict EXTERNAL_RAM_TABLE

--- a/Source/pyboy/core/cartridge/cartridge.pxd
+++ b/Source/pyboy/core/cartridge/cartridge.pxd
@@ -12,7 +12,7 @@ import cython
 from libc.stdint cimport uint8_t, uint16_t, uint32_t
 
 
-cdef BaseMBC Cartridge(unicode)
+cpdef BaseMBC Cartridge(unicode)
 cdef bint validate_checksum(uint8_t[:,:])
 
 @cython.locals(romdata=array, banksize=int)

--- a/Source/pyboy/core/cartridge/cartridge.py
+++ b/Source/pyboy/core/cartridge/cartridge.py
@@ -20,7 +20,7 @@ except ImportError:
     cythonmode = False
 
 
-def Cartridge(filename):
+def load_cartridge(filename):
     rombanks = load_romfile(filename)
     if not validate_checksum(rombanks):
         raise Exception("Cartridge header checksum mismatch!")

--- a/Source/pyboy/core/mb.py
+++ b/Source/pyboy/core/mb.py
@@ -22,7 +22,7 @@ class Motherboard:
         self.window = window
         self.timer = timer.Timer()
         self.interaction = interaction.Interaction()
-        self.cartridge = cartridge.Cartridge(gamerom_file)
+        self.cartridge = cartridge.load_cartridge(gamerom_file)
         self.bootrom = bootrom.BootROM(bootrom_file)
         self.ram = ram.RAM(random=False)
         self.cpu = cpu.CPU(self, profiling)

--- a/Source/setup.py
+++ b/Source/setup.py
@@ -44,10 +44,9 @@ setup(
             "pdoc3",
         ],
     },
-    include_dirs=[".", "pyboy", "pyboy/cartridge", "pyboy/window", "pyboy/core", "pyboy/debug"],
+    include_dirs=[".", "pyboy", "pyboy/cartridge", "pyboy/window", "pyboy/core", "pyboy/botsupport"],
     zip_safe=False,
     ext_modules=cythonize([
-        # 'pyboy/cartridge/cartridge.py',
         'pyboy/__init__.py',
         'pyboy/botsupport/sprite.py',
         'pyboy/botsupport/spritetracker.py',
@@ -57,6 +56,7 @@ setup(
         'pyboy/core/bootrom.py',
         'pyboy/core/cartridge/__init__.py',
         'pyboy/core/cartridge/base_mbc.py',
+        'pyboy/core/cartridge/cartridge.py',
         'pyboy/core/cartridge/mbc1.py',
         'pyboy/core/cartridge/mbc2.py',
         'pyboy/core/cartridge/mbc3.py',
@@ -86,6 +86,7 @@ setup(
         include_path=[".", "pyboy", "pyboy/botsupport", "pyboy/cartridge", "pyboy/core", "pyboy/window"],
         nthreads=thread_count,
         annotate=False,
+        gdb_debug=False,
         language_level=2,
         compiler_directives={
             "cdivision": True,

--- a/Source/setup.py
+++ b/Source/setup.py
@@ -12,6 +12,8 @@ thread_count = cpu_count()
 print("Thread Count:", thread_count)
 
 
+module_dirs = [".", "pyboy", "pyboy/core", "pyboy/core/cartridge", "pyboy/window", "pyboy/botsupport"]
+
 setup(
     name='PyBoy',
     version='0.1',
@@ -44,7 +46,7 @@ setup(
             "pdoc3",
         ],
     },
-    include_dirs=[".", "pyboy", "pyboy/cartridge", "pyboy/window", "pyboy/core", "pyboy/botsupport"],
+    include_dirs=module_dirs,
     zip_safe=False,
     ext_modules=cythonize([
         'pyboy/__init__.py',
@@ -83,7 +85,7 @@ setup(
         'pyboy/window/window_sdl2.py',
         'pyboy/windowevent.py',
         ],
-        include_path=[".", "pyboy", "pyboy/botsupport", "pyboy/cartridge", "pyboy/core", "pyboy/window"],
+        include_path=module_dirs,
         nthreads=thread_count,
         annotate=False,
         gdb_debug=False,

--- a/Source/setup.py
+++ b/Source/setup.py
@@ -20,7 +20,6 @@ setup(
     author="Mads Ynddal",
     author_email="mads-pyboy@ynddal.dk",
     long_description=long_description,
-    content_type="text/markdown",
     url="https://github.com/Baekalfen/PyBoy",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Allows cythonization of `cartridge.py`, which was not previously possible because a list of arrays cannot be made into a memoryview, and also because cython didn't detect or report this error, and instead segfaulted due to some buggy error handling code.

I'm hoping that not leaving out the cartridge module will fix the problems we've had trying to compile on Windows as well.

Also fixes #83.