### PR TITLE
Windows compatibility via MSYS2 and MinGW 

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -7,7 +7,9 @@ THREADS := 6
 PY := python3
 PYPY := pypy3
 NUMPY := $(shell ${PY} -c 'import numpy; print(numpy.get_include())')
-SDL := $(shell sdl2-config --cflags --libs)
+# The cut strips -mwindows from the mingw's output in windows; won't
+# affect other OS's since neither has lines of more than 3 elements.
+SDL := $(shell sdl2-config --cflags --libs | cut -d' ' -f 1-4)
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 
 build:
@@ -21,6 +23,7 @@ clean:
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.so" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.c" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.h" -delete
+	find ${ROOT_DIR}/Source/pyboy/ -name "*.dll" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "*.html" -delete
 	find ${ROOT_DIR}/Source/pyboy/ -name "__pycache__" -delete
 	rm -rf ${ROOT_DIR}/Source/build

--- a/Source/pyboy/window/window_scanline.pxd
+++ b/Source/pyboy/window/window_scanline.pxd
@@ -76,7 +76,7 @@ cdef class ScanlineWindow(BaseWindow):
         sdl2.SDL_UpdateTexture(self._screenbuf,
                                &self._linerect,
                                &self._linebuf,
-                               160)
+                               4 * COLS)
 
     cdef inline void _render_copy(self):
         sdl2.SDL_RenderCopy(


### PR DESCRIPTION
These changes allow PyBoy to run on Windows following the instructions I added today to the wiki.