### PR TITLE
Adds __main__.py to ignore cythonize files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ def define_lib_includes_cflags():
 
 
 def prep_pxd_py_files():
-    ignore_py_files = ['generator.py']
+    ignore_py_files = ['__main__.py', 'generator.py']
     # Cython doesn't trigger a recompile on .py files, where only the .pxd file has changed. So we fix this here.
     # We also yield the py_files that have a .pxd file, as we feed these into the cythonize call.
     for root, dirs, files in os.walk(ROOT_DIR):


### PR DESCRIPTION
Cythonizing the main script prevents running the module as `python -m pyboy` in directory. It seems that installing avoids this somehow but we should make it work anyway.