### PR TITLE
Replace unix-specific '/' with platform-agnostic os.sep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ if CYTHON and 'clean' not in sys.argv:
 
     py_pxd_files = prep_pxd_py_files()
     cythonize_files = map(lambda src: Extension(
-        src.split('.')[0].replace('/', '.'), [src],
+        src.split('.')[0].replace(os.sep, '.'), [src],
         include_dirs=includes,
         library_dirs=libdirs,
         libraries=libs,


### PR DESCRIPTION
One-line change in `setup.py`, allows `setup.py` to run on windows again. Tested on windows and linux ~~(don't have macOS availabe atm, but I don't see any reason it would fail)~~ and macOS.