### PR TITLE
Add get_scanline_parameters method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ bootrom/pyboy.png
 bootrom/PYBOY_ROM.bin
 
 pyboy.tar.gz
+test.replay

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -444,6 +444,10 @@ class PyBoy:
         """
         return (self.mb.lcd.getviewport(), self.mb.lcd.getwindowpos())
 
+    def get_scanline_parameters(self):
+        """Return the scanline parameters"""
+        return self.window.get_scanline_parameters()
+
     def save_state(self, file_like_object):
         """
         Saves the complete state of the emulator. It can be called at any time, and enable you to revert any progress in

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -428,7 +428,6 @@ class PyBoy:
         """
         return botsupport.TileMap(self.mb, window=True)
 
-    # TODO: We actually need the scanline_parameters. Mario might always report (0,0) at the end of frame.
     def get_screen_position(self):
         """
         These coordinates define the offset in the tile map from where the top-left corner of the screen is place. Note
@@ -444,8 +443,17 @@ class PyBoy:
         """
         return (self.mb.lcd.getviewport(), self.mb.lcd.getwindowpos())
 
-    def get_scanline_parameters(self):
-        """Return the scanline parameters"""
+    def get_screen_position_list(self):
+        """
+        This function provides the screen (SCX, SCY) and window (WX. WY) position for each horizontal line in the
+        screen buffer. These parameters are often used for visual effects, and some games will reset the registers at
+        the end of each call to `PyBoy.tick()`. For such games, `get_screen_position` becomes useless.
+
+        See `get_screen_position` for more information.
+
+        Returns:
+            numpy.ndarray: SCX, SCY, WX and WY for each scanline (144, 4).
+        """
         return self.window.get_scanline_parameters()
 
     def save_state(self, file_like_object):

--- a/pyboy/utils.pxd
+++ b/pyboy/utils.pxd
@@ -1,0 +1,23 @@
+#
+# License: See LICENSE file
+# GitHub: https://github.com/Baekalfen/PyBoy
+#
+
+cimport cython
+
+from libc.stdint cimport uint8_t, int64_t
+
+
+cdef class IntIOInterface:
+    cdef int64_t write(self, uint8_t)
+    cdef uint8_t read(self)
+    cdef void seek(self, int64_t)
+    cdef void flush(self)
+
+##############################################################
+# Buffer wrappers
+##############################################################
+
+cdef class IntIOWrapper(IntIOInterface):
+    cdef object buffer
+

--- a/pyboy/window/base_window.py
+++ b/pyboy/window/base_window.py
@@ -65,6 +65,9 @@ class BaseWindow:
     def get_screen_buffer_as_ndarray(self):
         raise NotImplementedError()
 
+    def get_scanline_parameters(self):
+        raise NotImplementedError()
+
     def update_cache(self, lcd):
         pass
 

--- a/pyboy/window/window_sdl2.py
+++ b/pyboy/window/window_sdl2.py
@@ -178,6 +178,15 @@ class SDLWindow(BaseWindow):
         self._scanlineparameters[y][2] = wx
         self._scanlineparameters[y][3] = wy
 
+    def get_scanline_parameters(self):
+        import numpy as np
+        return np.vstack(
+            [
+                np.array([line[0], line[1], line[2], line[3]], dtype=np.uint8)
+                for line in self._scanlineparameters
+            ]
+        )
+
     def render_screen(self, lcd):
         # All VRAM addresses are offset by 0x8000
         # Following addresses are 0x9800 and 0x9C00

--- a/pyboy/window/window_sdl2.py
+++ b/pyboy/window/window_sdl2.py
@@ -178,15 +178,6 @@ class SDLWindow(BaseWindow):
         self._scanlineparameters[y][2] = wx
         self._scanlineparameters[y][3] = wy
 
-    def get_scanline_parameters(self):
-        import numpy as np
-        return np.vstack(
-            [
-                np.array([line[0], line[1], line[2], line[3]], dtype=np.uint8)
-                for line in self._scanlineparameters
-            ]
-        )
-
     def render_screen(self, lcd):
         # All VRAM addresses are offset by 0x8000
         # Following addresses are 0x9800 and 0x9C00
@@ -294,6 +285,15 @@ class SDLWindow(BaseWindow):
     def get_screen_buffer_as_ndarray(self):
         import numpy as np
         return np.frombuffer(self.get_screen_buffer(), dtype=np.uint8).reshape(ROWS, COLS, 4)[:, :, :-1]
+
+    def get_scanline_parameters(self):
+        import numpy as np
+        return np.vstack(
+             [
+                 np.array([line[0], line[1], line[2], line[3]], dtype=np.uint8)
+                 for line in self._scanlineparameters
+             ]
+         )
 
     def get_screen_image(self):
         if not Image:

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -12,8 +12,8 @@ import PIL
 import pytest
 from pyboy import PyBoy, botsupport, windowevent
 
-boot_rom = "ROMs/DMG_ROM.bin"
-tetris_rom = "ROMs/Tetris.gb"
+from .utils import boot_rom, supermarioland_rom, tetris_rom
+
 any_rom = tetris_rom
 
 
@@ -392,4 +392,41 @@ def test_disable_title():
     pyboy = PyBoy(any_rom, window_type="dummy", disable_input=True, hide_window=True)
     pyboy.disable_title()
     pyboy.tick()
+    pyboy.stop(save=False)
+
+
+def test_screen_position_list():
+    pyboy = PyBoy(supermarioland_rom, window_type="headless", disable_input=True, hide_window=True)
+    pyboy.disable_title()
+    for _ in range(100):
+        pyboy.tick()
+
+    # Start the game
+    pyboy.send_input(windowevent.PRESS_BUTTON_START)
+    pyboy.tick()
+    pyboy.send_input(windowevent.RELEASE_BUTTON_START)
+
+    # Move right for 100 frame
+    pyboy.send_input(windowevent.PRESS_ARROW_RIGHT)
+    for _ in range(100):
+        pyboy.tick()
+
+    # Get screen positions, and verify the values
+    positions = pyboy.get_screen_position_list()
+    for y in range(1, 16):
+        assert positions[y][0] == 0 # HUD
+    for y in range(16, 144):
+        assert positions[y][0] == 49 # Actual screen position
+
+    # Progress another 10 frames to see and increase in SCX
+    for _ in range(10):
+        pyboy.tick()
+
+    # Get screen positions, and verify the values
+    positions = pyboy.get_screen_position_list()
+    for y in range(1, 16):
+        assert positions[y][0] == 0 # HUD
+    for y in range(16, 144):
+        assert positions[y][0] == 59 # Actual screen position
+
     pyboy.stop(save=False)


### PR DESCRIPTION
Hi, 

Not sure if this is generally useful -- this PR adds a method to retrieve the `_scanlineparameters` from the window object. It's implemented only for the `SDLWindow` and children, and returns a list of lists, one per scanline, with the position(s) in the tilemap used for each scanline per frame. 

From experimentation, this seems to work well. There's a comment on `get_screen_position` with a TODO about retrieving the scanline parameters instead -- not sure if this meets that requirement. 

Happy to flesh this out a bit to get it up to scratch! 