### PR TITLE
Skip test_screen_buffer_and_image with only default_rom

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -11,7 +11,7 @@ from pyboy import PyBoy, WindowEvent
 from pyboy import __main__ as main
 from pyboy.botsupport.tile import Tile
 
-from .utils import boot_rom, default_rom, kirby_rom
+from tests.utils import boot_rom, default_rom, kirby_rom
 
 
 @pytest.mark.skipif(not boot_rom, reason="ROM not present")

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -13,7 +13,7 @@ import pytest
 from pyboy import PyBoy, WindowEvent
 from pyboy.botsupport.tile import Tile
 
-from .utils import any_rom, boot_rom, default_rom, supermarioland_rom, tetris_rom
+from tests.utils import any_rom, boot_rom, default_rom, supermarioland_rom, tetris_rom
 
 
 def test_misc():
@@ -62,7 +62,7 @@ def test_tiles():
     pyboy.stop(save=False)
 
 
-@pytest.mark.skipif(not (boot_rom and any_rom), reason="ROM not present")
+@pytest.mark.skipif(not boot_rom or any_rom == default_rom, reason="ROM not present")
 def test_screen_buffer_and_image():
     cformat = "RGBA"
     boot_logo_hash_predigested = b"=\xff\xf9z 6\xf0\xe9\xcb\x05J`PM5\xd4rX+\x1b~z\xef1\xe0\x82\xc4t\x06\x82\x12C"

--- a/tests/test_openai_gym.py
+++ b/tests/test_openai_gym.py
@@ -11,7 +11,7 @@ import pytest
 from pyboy import PyBoy, WindowEvent
 from pyboy.botsupport.constants import COLS, ROWS
 
-from .utils import tetris_rom
+from tests.utils import tetris_rom
 
 is_pypy = platform.python_implementation() == "PyPy"
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 from pyboy import PyBoy, WindowEvent
 
-from . import utils
+from tests import utils
 
 event_filter = [
     WindowEvent.PRESS_SPEED_UP,

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -7,8 +7,8 @@ import os
 
 import pytest
 
-from .test_replay import replay
-from .utils import default_rom
+from tests.test_replay import replay
+from tests.utils import default_rom
 
 replay_file = "tests/replays/default_rom.replay"
 


### PR DESCRIPTION
The test requires the proprietary boot log which is not present in the
default rom.

Also clean up imports as They were not working cleanly in both pytest
from the command line and Pycharm.