### PR TITLE
Implement Random RAM

### DIFF
--- a/pyboy/__main__.py
+++ b/pyboy/__main__.py
@@ -36,6 +36,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("ROM", type=valid_file_path, help="Path to a Game Boy compatible ROM file")
 parser.add_argument("-b", "--bootrom", type=valid_file_path, help="Path to a boot-ROM file")
 parser.add_argument("--profiling", action="store_true", help="Enable opcode profiling (internal use)")
+parser.add_argument("--randomize-ram", action="store_true", help="Randomize Game Boy RAM on startup")
 parser.add_argument(
     "--log-level",
     default="INFO",

--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -5,6 +5,7 @@
 
 from array import array
 from ctypes import c_void_p
+from random import getrandbits
 
 from pyboy.utils import color_code
 
@@ -22,7 +23,7 @@ except ImportError:
 
 
 class LCD:
-    def __init__(self):
+    def __init__(self, randomize=False):
         self.VRAM = array("B", [0] * VIDEO_RAM)
         self.OAM = array("B", [0] * OBJECT_ATTRIBUTE_MEMORY)
 
@@ -38,6 +39,12 @@ class LCD:
         self.OBP1 = PaletteRegister(0xFF)
         self.WY = 0x00
         self.WX = 0x00
+
+        if randomize:
+            for i in range(VIDEO_RAM):
+                self.VRAM[i] = getrandbits(8)
+            for i in range(OBJECT_ATTRIBUTE_MEMORY):
+                self.OAM[i] = getrandbits(8)
 
     def save_state(self, f):
         for n in range(VIDEO_RAM):

--- a/pyboy/core/mb.py
+++ b/pyboy/core/mb.py
@@ -27,7 +27,7 @@ class Motherboard:
         self.interaction = interaction.Interaction()
         self.cartridge = cartridge.load_cartridge(gamerom_file)
         self.bootrom = bootrom.BootROM(bootrom_file)
-        self.ram = ram.RAM(random=False)
+        self.ram = ram.RAM(is_random=True)
         self.cpu = cpu.CPU(self, profiling)
         self.lcd = lcd.LCD()
         self.renderer = lcd.Renderer(color_palette)

--- a/pyboy/core/mb.py
+++ b/pyboy/core/mb.py
@@ -27,7 +27,7 @@ class Motherboard:
         self.interaction = interaction.Interaction()
         self.cartridge = cartridge.load_cartridge(gamerom_file)
         self.bootrom = bootrom.BootROM(bootrom_file)
-        self.ram = ram.RAM(is_random=True)
+        self.ram = ram.RAM(randomize=True)
         self.cpu = cpu.CPU(self, profiling)
         self.lcd = lcd.LCD()
         self.renderer = lcd.Renderer(color_palette)

--- a/pyboy/core/mb.py
+++ b/pyboy/core/mb.py
@@ -16,7 +16,8 @@ STAT, _, _, LY, LYC = range(0xFF41, 0xFF46)
 
 
 class Motherboard:
-    def __init__(self, gamerom_file, bootrom_file, color_palette, disable_renderer, sound_enabled, profiling=False):
+    def __init__(self, gamerom_file, bootrom_file, color_palette, disable_renderer, sound_enabled, randomize=False,
+                 profiling=False):
         if bootrom_file is not None:
             logger.info("Boot-ROM file provided")
 
@@ -27,9 +28,9 @@ class Motherboard:
         self.interaction = interaction.Interaction()
         self.cartridge = cartridge.load_cartridge(gamerom_file)
         self.bootrom = bootrom.BootROM(bootrom_file)
-        self.ram = ram.RAM(randomize=True)
+        self.ram = ram.RAM(randomize=randomize)
         self.cpu = cpu.CPU(self, profiling)
-        self.lcd = lcd.LCD()
+        self.lcd = lcd.LCD(randomize=randomize)
         self.renderer = lcd.Renderer(color_palette)
         self.disable_renderer = disable_renderer
         self.sound_enabled = sound_enabled

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -6,8 +6,6 @@
 import array
 import random
 
-REGISTER_MAX = 0xFF
-
 # MEMORY SIZES
 INTERNAL_RAM0 = 8 * 1024 # 8KiB
 NON_IO_INTERNAL_RAM0 = 0x60

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -17,20 +17,18 @@ INTERRUPT_ENABLE_REGISTER = 1
 
 class RAM:
     def __init__(self, randomize=False):
-        typecode = "B"
-
-        self.internal_ram0 = array.array(typecode, [0] * (INTERNAL_RAM0))
-        self.non_io_internal_ram0 = array.array(typecode, [0] * (NON_IO_INTERNAL_RAM0))
-        self.io_ports = array.array(typecode, [0] * (IO_PORTS))
-        self.internal_ram1 = array.array(typecode, [0] * (INTERNAL_RAM1))
-        self.non_io_internal_ram1 = array.array(typecode, [0] * (NON_IO_INTERNAL_RAM1))
-        self.interrupt_register = array.array(typecode, [0] * (INTERRUPT_ENABLE_REGISTER))
+        self.internal_ram0 = array.array("B", [0] * (INTERNAL_RAM0))
+        self.non_io_internal_ram0 = array.array("B", [0] * (NON_IO_INTERNAL_RAM0))
+        self.io_ports = array.array("B", [0] * (IO_PORTS))
+        self.internal_ram1 = array.array("B", [0] * (INTERNAL_RAM1))
+        self.non_io_internal_ram1 = array.array("B", [0] * (NON_IO_INTERNAL_RAM1))
+        self.interrupt_register = array.array("B", [0] * (INTERRUPT_ENABLE_REGISTER))
 
         if randomize: # NOTE: In real life, the RAM is scrambled with random data on boot.
-            for a in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
+            for mem in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
                       self.non_io_internal_ram1, self.interrupt_register):
-                for i in range(len(a)):
-                    a[i] = random.getrandbits(8)
+                for i in range(len(mem)):
+                    mem[i] = random.getrandbits(8)
 
     def save_state(self, f):
         for n in range(INTERNAL_RAM0):

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -3,8 +3,8 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import array
-import random
+from array import array
+from random import getrandbits
 
 # MEMORY SIZES
 INTERNAL_RAM0 = 8 * 1024 # 8KiB
@@ -17,18 +17,22 @@ INTERRUPT_ENABLE_REGISTER = 1
 
 class RAM:
     def __init__(self, randomize=False):
-        self.internal_ram0 = array.array("B", [0] * (INTERNAL_RAM0))
-        self.non_io_internal_ram0 = array.array("B", [0] * (NON_IO_INTERNAL_RAM0))
-        self.io_ports = array.array("B", [0] * (IO_PORTS))
-        self.internal_ram1 = array.array("B", [0] * (INTERNAL_RAM1))
-        self.non_io_internal_ram1 = array.array("B", [0] * (NON_IO_INTERNAL_RAM1))
-        self.interrupt_register = array.array("B", [0] * (INTERRUPT_ENABLE_REGISTER))
+        self.internal_ram0 = array("B", [0] * (INTERNAL_RAM0))
+        self.non_io_internal_ram0 = array("B", [0] * (NON_IO_INTERNAL_RAM0))
+        self.io_ports = array("B", [0] * (IO_PORTS))
+        self.internal_ram1 = array("B", [0] * (INTERNAL_RAM1))
+        self.non_io_internal_ram1 = array("B", [0] * (NON_IO_INTERNAL_RAM1))
+        self.interrupt_register = array("B", [0] * (INTERRUPT_ENABLE_REGISTER))
 
-        if randomize: # NOTE: In real life, the RAM is scrambled with random data on boot.
-            for mem in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
-                      self.non_io_internal_ram1, self.interrupt_register):
-                for i in range(len(mem)):
-                    mem[i] = random.getrandbits(8)
+        if randomize:
+            for i in range(INTERNAL_RAM0):
+                self.internal_ram0[i] = getrandbits(8)
+            for i in range(NON_IO_INTERNAL_RAM0):
+                self.non_io_internal_ram0[i] = getrandbits(8)
+            for i in range(INTERNAL_RAM1):
+                self.internal_ram1[i] = getrandbits(8)
+            for i in range(NON_IO_INTERNAL_RAM1):
+                self.non_io_internal_ram1[i] = getrandbits(8)
 
     def save_state(self, f):
         for n in range(INTERNAL_RAM0):

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -4,9 +4,12 @@
 #
 
 import array
+import random
+
+import numpy
 
 # MEMORY SIZES
-INTERNAL_RAM0 = 8 * 1024 # 8KB
+INTERNAL_RAM0 = 8 * 1024 # 8KiB
 NON_IO_INTERNAL_RAM0 = 0x60
 IO_PORTS = 0x4C
 NON_IO_INTERNAL_RAM1 = 0x34
@@ -15,16 +18,24 @@ INTERRUPT_ENABLE_REGISTER = 1
 
 
 class RAM:
-    def __init__(self, random=False):
-        if random: # NOTE: In real life, the RAM is scrambled with random data on boot.
-            raise Exception("Random RAM not implemented")
+    def __init__(self, is_random=False):
+        typecode = "B"
 
-        self.internal_ram0 = array.array("B", [0] * (INTERNAL_RAM0))
-        self.non_io_internal_ram0 = array.array("B", [0] * (NON_IO_INTERNAL_RAM0))
-        self.io_ports = array.array("B", [0] * (IO_PORTS))
-        self.internal_ram1 = array.array("B", [0] * (INTERNAL_RAM1))
-        self.non_io_internal_ram1 = array.array("B", [0] * (NON_IO_INTERNAL_RAM1))
-        self.interrupt_register = array.array("B", [0] * (INTERRUPT_ENABLE_REGISTER))
+        self.internal_ram0 = array.array(typecode, [0] * (INTERNAL_RAM0))
+        self.non_io_internal_ram0 = array.array(typecode, [0] * (NON_IO_INTERNAL_RAM0))
+        self.io_ports = array.array(typecode, [0] * (IO_PORTS))
+        self.internal_ram1 = array.array(typecode, [0] * (INTERNAL_RAM1))
+        self.non_io_internal_ram1 = array.array(typecode, [0] * (NON_IO_INTERNAL_RAM1))
+        self.interrupt_register = array.array(typecode, [0] * (INTERRUPT_ENABLE_REGISTER))
+
+        if is_random: # NOTE: In real life, the RAM is scrambled with random data on boot.
+            # Gives us the upper bound value of the "B" typecode
+            typecode_max = numpy.iinfo(numpy.dtype(typecode)).max
+
+            for a in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
+                      self.non_io_internal_ram1, self.interrupt_register):
+                for i in range(len(a)):
+                    a[i] = random.randrange(typecode_max + 1)
 
     def save_state(self, f):
         for n in range(INTERNAL_RAM0):

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -32,7 +32,7 @@ class RAM:
             for a in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
                       self.non_io_internal_ram1, self.interrupt_register):
                 for i in range(len(a)):
-                    a[i] = random.randrange(REGISTER_MAX + 1)
+                    a[i] = random.getrandbits(8)
 
     def save_state(self, f):
         for n in range(INTERNAL_RAM0):

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -6,7 +6,7 @@
 import array
 import random
 
-import numpy
+REGISTER_MAX = 0xFF
 
 # MEMORY SIZES
 INTERNAL_RAM0 = 8 * 1024 # 8KiB
@@ -18,7 +18,7 @@ INTERRUPT_ENABLE_REGISTER = 1
 
 
 class RAM:
-    def __init__(self, is_random=False):
+    def __init__(self, randomize=False):
         typecode = "B"
 
         self.internal_ram0 = array.array(typecode, [0] * (INTERNAL_RAM0))
@@ -28,14 +28,11 @@ class RAM:
         self.non_io_internal_ram1 = array.array(typecode, [0] * (NON_IO_INTERNAL_RAM1))
         self.interrupt_register = array.array(typecode, [0] * (INTERRUPT_ENABLE_REGISTER))
 
-        if is_random: # NOTE: In real life, the RAM is scrambled with random data on boot.
-            # Gives us the upper bound value of the "B" typecode
-            typecode_max = numpy.iinfo(numpy.dtype(typecode)).max
-
+        if randomize: # NOTE: In real life, the RAM is scrambled with random data on boot.
             for a in (self.internal_ram0, self.non_io_internal_ram0, self.io_ports, self.internal_ram1,
                       self.non_io_internal_ram1, self.interrupt_register):
                 for i in range(len(a)):
-                    a[i] = random.randrange(typecode_max + 1)
+                    a[i] = random.randrange(REGISTER_MAX + 1)
 
     def save_state(self, f):
         for n in range(INTERNAL_RAM0):

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -30,7 +30,8 @@ defaults = {
 
 class PyBoy:
     def __init__(
-        self, gamerom_file, *, bootrom_file=None, profiling=False, disable_renderer=False, sound=False, **kwargs
+            self, gamerom_file, *, bootrom_file=None, profiling=False, disable_renderer=False, sound=False,
+            randomize=False, **kwargs
     ):
         """
         PyBoy is loadable as an object in Python. This means, it can be initialized from another script, and be
@@ -70,6 +71,7 @@ class PyBoy:
             kwargs["color_palette"],
             disable_renderer,
             sound,
+            randomize=randomize,
             profiling=profiling,
         )
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -170,3 +170,25 @@ def test_tilemaps():
     assert isinstance(wdw_tilemap[0, 0], Tile)
 
     pyboy.stop(save=False)
+
+
+def test_randomize_ram():
+    pyboy = PyBoy(default_rom) # randomize=False, by default
+    # RAM banks should all be 0 by default
+    assert not any([pyboy.get_memory_value(x) for x in range(0x8000, 0xA000)]), "VRAM not zeroed"
+    assert not any([pyboy.get_memory_value(x) for x in range(0xC000, 0xE000)]), "Internal RAM 0 not zeroed"
+    assert not any([pyboy.get_memory_value(x) for x in range(0xFE00, 0xFEA0)]), "OAM not zeroed"
+    assert not any([pyboy.get_memory_value(x) for x in range(0xFEA0, 0xFF00)]), "Non-IO internal RAM 0 not zeroed"
+    assert not any([pyboy.get_memory_value(x) for x in range(0xFF4C, 0xFF80)]), "Non-IO internal RAM 1 not zeroed"
+    assert not any([pyboy.get_memory_value(x) for x in range(0xFF80, 0xFFFF)]), "Internal RAM 1 not zeroed"
+    pyboy.stop(save=False)
+
+    pyboy = PyBoy(default_rom, randomize=True)
+    # RAM banks should have nonzero values now
+    assert any([pyboy.get_memory_value(x) for x in range(0x8000, 0xA000)]), "VRAM not randomized"
+    assert any([pyboy.get_memory_value(x) for x in range(0xC000, 0xE000)]), "Internal RAM 0 not randomized"
+    assert any([pyboy.get_memory_value(x) for x in range(0xFE00, 0xFEA0)]), "OAM not randomized"
+    assert any([pyboy.get_memory_value(x) for x in range(0xFEA0, 0xFF00)]), "Non-IO internal RAM 0 not randomized"
+    assert any([pyboy.get_memory_value(x) for x in range(0xFF4C, 0xFF80)]), "Non-IO internal RAM 1 not randomized"
+    assert any([pyboy.get_memory_value(x) for x in range(0xFF80, 0xFFFF)]), "Internal RAM 1 not randomized"
+    pyboy.stop(save=False)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -72,7 +72,8 @@ def replay(
     rewind=False,
     bootrom_file=utils.boot_rom,
     overwrite=RESET_REPLAYS,
-    gif_hash=None
+    gif_hash=None,
+    randomize=False
 ):
     with open(replay, "rb") as f:
         recorded_input, b64_romhash, b64_state = json.loads(zlib.decompress(f.read()).decode("ascii"))
@@ -86,6 +87,7 @@ def replay(
         bootrom_file=bootrom_file,
         disable_input=True,
         rewind=rewind,
+        randomize=randomize,
         record_input=(RESET_REPLAYS and window in ["SDL2", "headless", "OpenGL"])
     )
     pyboy.set_emulation_speed(0)
@@ -187,7 +189,8 @@ def test_supermarioland_gif():
         "tests/replays/supermarioland_gif.replay",
         record_gif=(122, 644),
         gif_destination="README/3.gif",
-        gif_hash="15aVUmwtTq38E3SB91moQLYSTZVWuTNTUmzYVSgTg38="
+        gif_hash="15aVUmwtTq38E3SB91moQLYSTZVWuTNTUmzYVSgTg38=",
+        randomize=True
     )
 
 


### PR DESCRIPTION
If the random flag is set, iterate through the existing RAM arrays and
randomize the values.

While there are no specific RAM unit tests, I played through some of the
ROMs I have locally and the games seemed to be running fine.