### PR TITLE
closes #152

### DIFF
--- a/pyboy/__main__.py
+++ b/pyboy/__main__.py
@@ -5,17 +5,15 @@
 #
 
 import argparse
-import logging
 import os
 
 from pyboy import PyBoy, core
 from pyboy.logger import log_level
 from pyboy.plugins.manager import parser_arguments
 from pyboy.pyboy import defaults
+from pyboy.logger import logger
 
 INTERNAL_LOADSTATE = "INTERNAL_LOADSTATE_TOKEN"
-
-logger = logging.getLogger(__name__)
 
 
 def color_tuple(string):

--- a/pyboy/core/cartridge/base_mbc.py
+++ b/pyboy/core/cartridge/base_mbc.py
@@ -11,7 +11,7 @@ from pyboy.utils import IntIOWrapper
 
 from .rtc import RTC
 
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 
 class BaseMBC:

--- a/pyboy/core/cartridge/mbc5.py
+++ b/pyboy/core/cartridge/mbc5.py
@@ -6,8 +6,7 @@
 import logging
 
 from .base_mbc import BaseMBC
-
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 
 class MBC5(BaseMBC):

--- a/pyboy/logger.py
+++ b/pyboy/logger.py
@@ -3,15 +3,25 @@
 # GitHub: https://github.com/baekalfen/PyBoy
 #
 
+import os
 import logging
 
-logger = logging.getLogger()
-logger.setLevel(logging.ERROR)
-logging.basicConfig(format="%(relativeCreated)-8d %(name)-30s %(levelname)-8s %(message)s")
+LOGLEVEL = os.environ.get("PYBOY_LOGLEVEL", "INFO")
+
+handler = logging.StreamHandler()
+handler.setFormatter(
+    logging.Formatter(
+        "%(relativeCreated)-8d %(name)-30s %(levelname)-8s %(message)s"
+        )
+    )
+
+logger = logging.getLogger("pyboy")
+logger.setLevel(LOGLEVEL)
+logger.addHandler(handler)
 
 
 def log_level(level):
     if level == "DISABLE":
         logging.disable(level=logging.CRITICAL)
     else:
-        logger.setLevel(getattr(logging, level))
+        logger.setLevel(level)

--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -4,7 +4,6 @@
 #
 
 import ctypes
-import logging
 from array import array
 
 import sdl2
@@ -13,8 +12,8 @@ from pyboy.botsupport.sprite import Sprite
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.plugins.window_sdl2 import sdl2_event_pump
 from pyboy.utils import WindowEvent
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_kirby_dream_land.py
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.py
@@ -7,13 +7,10 @@ __pdoc__ = {
     "GameWrapperKirbyDreamLand.post_tick": False,
 }
 
-import logging
-
 from pyboy.utils import WindowEvent
-
+from pyboy.logger import logger
 from .base_plugin import PyBoyGameWrapper
 
-logger = logging.getLogger(__name__)
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_super_mario_land.py
+++ b/pyboy/plugins/game_wrapper_super_mario_land.py
@@ -7,14 +7,12 @@ __pdoc__ = {
     "GameWrapperSuperMarioLand.post_tick": False,
 }
 
-import logging
 
 import numpy as np
 from pyboy.utils import WindowEvent
-
+from pyboy.logger import logger
 from .base_plugin import PyBoyGameWrapper
 
-logger = logging.getLogger(__name__)
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_tetris.py
+++ b/pyboy/plugins/game_wrapper_tetris.py
@@ -7,15 +7,13 @@ __pdoc__ = {
     "GameWrapperTetris.post_tick": False,
 }
 
-import logging
 from array import array
 
 import numpy as np
 from pyboy.utils import WindowEvent
-
+from pyboy.logger import logger
 from .base_plugin import PyBoyGameWrapper
 
-logger = logging.getLogger(__name__)
 
 try:
     from cython import compiled

--- a/pyboy/plugins/record_replay.py
+++ b/pyboy/plugins/record_replay.py
@@ -7,13 +7,11 @@ import base64
 import hashlib
 import io
 import json
-import logging
 import zlib
 
 import numpy as np
 from pyboy.plugins.base_plugin import PyBoyPlugin
-
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 
 class RecordReplay(PyBoyPlugin):

--- a/pyboy/plugins/rewind.py
+++ b/pyboy/plugins/rewind.py
@@ -4,12 +4,10 @@
 #
 
 import array
-import logging
 
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import IntIOInterface, WindowEvent
-
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 try:
     from cython import compiled

--- a/pyboy/plugins/screen_recorder.py
+++ b/pyboy/plugins/screen_recorder.py
@@ -3,14 +3,13 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import logging
 import os
 import time
 
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import WindowEvent
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 try:
     from PIL import Image

--- a/pyboy/plugins/screenshot_recorder.py
+++ b/pyboy/plugins/screenshot_recorder.py
@@ -3,14 +3,13 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import logging
 import os
 import time
 
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import WindowEvent
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 try:
     from PIL import Image

--- a/pyboy/plugins/window_dummy.py
+++ b/pyboy/plugins/window_dummy.py
@@ -2,11 +2,9 @@
 # License: See LICENSE.md file
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
-import logging
 
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
-
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 
 class WindowDummy(PyBoyWindowPlugin):

--- a/pyboy/plugins/window_headless.py
+++ b/pyboy/plugins/window_headless.py
@@ -2,11 +2,9 @@
 # License: See LICENSE.md file
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
-import logging
 
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
-
-logger = logging.getLogger(__name__)
+from pyboy.logger import logger
 
 
 class WindowHeadless(PyBoyWindowPlugin):

--- a/pyboy/plugins/window_open_gl.py
+++ b/pyboy/plugins/window_open_gl.py
@@ -3,13 +3,11 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import logging
-
 import numpy as np
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.utils import WindowEvent
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 try:
     import OpenGL.GLUT.freeglut

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -3,15 +3,14 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-import logging
 from time import perf_counter
 
 import sdl2
 import sdl2.ext
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.utils import WindowEvent, WindowEventMouse
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 ROWS, COLS = 144, 160
 

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -6,7 +6,6 @@
 The core module of the emulator
 """
 
-import logging
 import os
 import time
 
@@ -17,8 +16,8 @@ from pyboy.utils import IntIOWrapper, WindowEvent
 
 from . import botsupport
 from .core.mb import Motherboard
+from pyboy.logger import logger
 
-logger = logging.getLogger(__name__)
 
 SPF = 1 / 60. # inverse FPS (frame-per-second)
 


### PR DESCRIPTION
1. Reworked how we instantiate and use the logging.Logger class
2. Removed the unnecessary re-instantiation of logging.Logger
3. Preserved the message formatting
4. Added support to change log level of the logger through environment
  variable.

Notes:
- The item [4] might be more useful in the future if the project manage to have time to plan a rework to organize the **argparse** usage.





