### PR TITLE
Fix OpenGL window closing, and others

### DIFF
--- a/pyboy/__main__.py
+++ b/pyboy/__main__.py
@@ -8,10 +8,9 @@ import argparse
 import os
 
 from pyboy import PyBoy, core
-from pyboy.logger import log_level
+from pyboy.logger import log_level, logger
 from pyboy.plugins.manager import parser_arguments
 from pyboy.pyboy import defaults
-from pyboy.logger import logger
 
 INTERNAL_LOADSTATE = "INTERNAL_LOADSTATE_TOKEN"
 

--- a/pyboy/core/cartridge/base_mbc.py
+++ b/pyboy/core/cartridge/base_mbc.py
@@ -7,11 +7,10 @@ import array
 import logging
 import os
 
+from pyboy.logger import logger
 from pyboy.utils import IntIOWrapper
 
 from .rtc import RTC
-
-from pyboy.logger import logger
 
 
 class BaseMBC:

--- a/pyboy/core/cartridge/mbc5.py
+++ b/pyboy/core/cartridge/mbc5.py
@@ -5,8 +5,9 @@
 
 import logging
 
-from .base_mbc import BaseMBC
 from pyboy.logger import logger
+
+from .base_mbc import BaseMBC
 
 
 class MBC5(BaseMBC):

--- a/pyboy/core/mb.py
+++ b/pyboy/core/mb.py
@@ -16,8 +16,16 @@ STAT, _, _, LY, LYC = range(0xFF41, 0xFF46)
 
 
 class Motherboard:
-    def __init__(self, gamerom_file, bootrom_file, color_palette, disable_renderer, sound_enabled, randomize=False,
-                 profiling=False):
+    def __init__(
+        self,
+        gamerom_file,
+        bootrom_file,
+        color_palette,
+        disable_renderer,
+        sound_enabled,
+        randomize=False,
+        profiling=False
+    ):
         if bootrom_file is not None:
             logger.info("Boot-ROM file provided")
 

--- a/pyboy/logger.py
+++ b/pyboy/logger.py
@@ -3,17 +3,13 @@
 # GitHub: https://github.com/baekalfen/PyBoy
 #
 
-import os
 import logging
+import os
 
 LOGLEVEL = os.environ.get("PYBOY_LOGLEVEL", "INFO")
 
 handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter(
-        "%(relativeCreated)-8d %(name)-30s %(levelname)-8s %(message)s"
-        )
-    )
+handler.setFormatter(logging.Formatter("%(relativeCreated)-8d %(name)-30s %(levelname)-8s %(message)s"))
 
 logger = logging.getLogger("pyboy")
 logger.setLevel(LOGLEVEL)

--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -9,11 +9,10 @@ from array import array
 import sdl2
 from pyboy.botsupport import constants, tilemap
 from pyboy.botsupport.sprite import Sprite
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.plugins.window_sdl2 import sdl2_event_pump
 from pyboy.utils import WindowEvent
-from pyboy.logger import logger
-
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_kirby_dream_land.py
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.py
@@ -7,10 +7,10 @@ __pdoc__ = {
     "GameWrapperKirbyDreamLand.post_tick": False,
 }
 
-from pyboy.utils import WindowEvent
 from pyboy.logger import logger
-from .base_plugin import PyBoyGameWrapper
+from pyboy.utils import WindowEvent
 
+from .base_plugin import PyBoyGameWrapper
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_super_mario_land.py
+++ b/pyboy/plugins/game_wrapper_super_mario_land.py
@@ -7,12 +7,11 @@ __pdoc__ = {
     "GameWrapperSuperMarioLand.post_tick": False,
 }
 
-
 import numpy as np
-from pyboy.utils import WindowEvent
 from pyboy.logger import logger
-from .base_plugin import PyBoyGameWrapper
+from pyboy.utils import WindowEvent
 
+from .base_plugin import PyBoyGameWrapper
 
 try:
     from cython import compiled

--- a/pyboy/plugins/game_wrapper_tetris.py
+++ b/pyboy/plugins/game_wrapper_tetris.py
@@ -10,10 +10,10 @@ __pdoc__ = {
 from array import array
 
 import numpy as np
-from pyboy.utils import WindowEvent
 from pyboy.logger import logger
-from .base_plugin import PyBoyGameWrapper
+from pyboy.utils import WindowEvent
 
+from .base_plugin import PyBoyGameWrapper
 
 try:
     from cython import compiled

--- a/pyboy/plugins/record_replay.py
+++ b/pyboy/plugins/record_replay.py
@@ -10,8 +10,8 @@ import json
 import zlib
 
 import numpy as np
-from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.logger import logger
+from pyboy.plugins.base_plugin import PyBoyPlugin
 
 
 class RecordReplay(PyBoyPlugin):

--- a/pyboy/plugins/rewind.py
+++ b/pyboy/plugins/rewind.py
@@ -5,9 +5,9 @@
 
 import array
 
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import IntIOInterface, WindowEvent
-from pyboy.logger import logger
 
 try:
     from cython import compiled

--- a/pyboy/plugins/screen_recorder.py
+++ b/pyboy/plugins/screen_recorder.py
@@ -6,10 +6,9 @@
 import os
 import time
 
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import WindowEvent
-from pyboy.logger import logger
-
 
 try:
     from PIL import Image

--- a/pyboy/plugins/screenshot_recorder.py
+++ b/pyboy/plugins/screenshot_recorder.py
@@ -6,10 +6,9 @@
 import os
 import time
 
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import WindowEvent
-from pyboy.logger import logger
-
 
 try:
     from PIL import Image

--- a/pyboy/plugins/window_dummy.py
+++ b/pyboy/plugins/window_dummy.py
@@ -3,8 +3,8 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.logger import logger
+from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 
 
 class WindowDummy(PyBoyWindowPlugin):

--- a/pyboy/plugins/window_dummy.py
+++ b/pyboy/plugins/window_dummy.py
@@ -20,4 +20,4 @@ class WindowDummy(PyBoyWindowPlugin):
         return self.pyboy_argv.get("window_type") == "dummy"
 
     def set_title(self, title):
-        logger.info(title.encode())
+        logger.info(title)

--- a/pyboy/plugins/window_headless.py
+++ b/pyboy/plugins/window_headless.py
@@ -3,8 +3,8 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
-from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.logger import logger
+from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 
 
 class WindowHeadless(PyBoyWindowPlugin):

--- a/pyboy/plugins/window_headless.py
+++ b/pyboy/plugins/window_headless.py
@@ -12,4 +12,4 @@ class WindowHeadless(PyBoyWindowPlugin):
         return self.pyboy_argv.get("window_type") == "headless"
 
     def set_title(self, title):
-        logger.info(title.encode())
+        logger.info(title)

--- a/pyboy/plugins/window_open_gl.py
+++ b/pyboy/plugins/window_open_gl.py
@@ -4,10 +4,9 @@
 #
 
 import numpy as np
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.utils import WindowEvent
-from pyboy.logger import logger
-
 
 try:
     import OpenGL.GLUT.freeglut

--- a/pyboy/plugins/window_open_gl.py
+++ b/pyboy/plugins/window_open_gl.py
@@ -151,3 +151,5 @@ class WindowOpenGL(PyBoyWindowPlugin):
 
     def stop(self):
         glutDestroyWindow(glutGetWindow())
+        for _ in range(10): # At least 2 to close
+            OpenGL.GLUT.freeglut.glutMainLoopEvent()

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -7,10 +7,9 @@ from time import perf_counter
 
 import sdl2
 import sdl2.ext
+from pyboy.logger import logger
 from pyboy.plugins.base_plugin import PyBoyWindowPlugin
 from pyboy.utils import WindowEvent, WindowEventMouse
-from pyboy.logger import logger
-
 
 ROWS, COLS = 144, 160
 
@@ -82,6 +81,7 @@ CONTROLLER_UP = {
     sdl2.SDL_CONTROLLER_BUTTON_GUIDE         : WindowEvent.RELEASE_SPEED_UP,
 }
 # yapf: enable
+
 
 def sdl2_event_pump(events):
     global _sdlcontroller

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -174,6 +174,8 @@ class WindowSDL2(PyBoyWindowPlugin):
 
     def stop(self):
         sdl2.SDL_DestroyWindow(self._window)
+        for _ in range(10): # At least 2 to close
+            sdl2.ext.get_events()
         sdl2.SDL_Quit()
 
 

--- a/pyboy/pyboy.pxd
+++ b/pyboy/pyboy.pxd
@@ -27,7 +27,8 @@ cdef class PyBoy:
 
     cdef list old_events
     cdef list events
-    cdef bint done
+    cdef bint quitting
+    cdef bint stopped
     cdef public str window_title
 
     cdef bint limit_emulationspeed
@@ -42,5 +43,3 @@ cdef class PyBoy:
     @cython.locals(done=cython.bint, event=int, t_start=float, t_cpu=float, t_emu=float, secs=float)
     cpdef bint tick(self)
     cpdef void stop(self, save=*)
-
-

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -9,6 +9,7 @@ The core module of the emulator
 import os
 import time
 
+from pyboy.logger import logger
 from pyboy.openai_gym import PyBoyGymEnv
 from pyboy.openai_gym import enabled as gym_enabled
 from pyboy.plugins.manager import PluginManager
@@ -16,8 +17,6 @@ from pyboy.utils import IntIOWrapper, WindowEvent
 
 from . import botsupport
 from .core.mb import Motherboard
-from pyboy.logger import logger
-
 
 SPF = 1 / 60. # inverse FPS (frame-per-second)
 
@@ -30,8 +29,15 @@ defaults = {
 
 class PyBoy:
     def __init__(
-            self, gamerom_file, *, bootrom_file=None, profiling=False, disable_renderer=False, sound=False,
-            randomize=False, **kwargs
+        self,
+        gamerom_file,
+        *,
+        bootrom_file=None,
+        profiling=False,
+        disable_renderer=False,
+        sound=False,
+        randomize=False,
+        **kwargs
     ):
         """
         PyBoy is loadable as an object in Python. This means, it can be initialized from another script, and be

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ class PyTest(test):
                     sys.exit(return_code)
 
         import pytest
-        args = ["tests/", f"-n{cpu_count()}", "-v", "--dist=loadfile"]
+        args = ["tests/", f"-n{cpu_count()}", "-v"]
         # args = ["tests/", "-v", "-x"] # No multithreading, fail fast
         if codecov: # TODO: There's probably a more correct way to read the argv flags
             args += ["--cov=./"]

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ class PyTest(test):
                     sys.exit(return_code)
 
         import pytest
-        args = ["tests/", f"-n{cpu_count()}", "-v"]
+        args = ["tests/", f"-n{cpu_count()}", "-v", "--dist=loadfile"]
         # args = ["tests/", "-v", "-x"] # No multithreading, fail fast
         if codecov: # TODO: There's probably a more correct way to read the argv flags
             args += ["--cov=./"]


### PR DESCRIPTION
Fixes #183. The OpenGL window needed a few calls to the GLUT loop event to process closing. While testing, I also noticed a few other unexpected things and fixed that. `PyBoy.stop()` will now only run once, which fixes crashing that occurred when `PyBoy.__del__` tried to close the OpenGL window twice.

Also I changed the `pytest-xdist` test scheduling, because faster is better. PyBoy doesn't use enough RAM to justify `--loadfile`.

`pre-commit` hasn't been running as a hook for me for some reason, so I ran it manually and threw that in as well. A lot of imports and argument lists got reformatted.