### PR TITLE
Cpu breakpoints

### DIFF
--- a/pyboy/core/cpu.pxd
+++ b/pyboy/core/cpu.pxd
@@ -78,3 +78,5 @@ cdef class CPU:
     @cython.locals(v=cython.int)
     cdef bint test_ramregisterflag(self, int, int)
     cdef void clear_ramregisterflag(self, int, int)
+
+    cdef dict breakpoints

--- a/pyboy/core/cpu.py
+++ b/pyboy/core/cpu.py
@@ -207,8 +207,9 @@ class CPU:
         elif self.halted:
             return -1
 
+        # TODO move this logic to the Motherboard?
         breakpoint_callback = self.breakpoints.get(self.PC)
         if breakpoint_callback:
-            breakpoint_callback(self.PC)
+            breakpoint_callback(self.PC, self.mb.cartridge.rambank_selected, self.mb.cartridge.rombank_selected)
 
         return self.fetch_and_execute(self.PC)

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -342,6 +342,33 @@ class PyBoy:
         # what the game writes to the address. This can be used so freeze the value for health, cash etc.
         self.mb.cartridge.overrideitem(rom_bank, addr, value)
 
+    def set_breakpoint(self, addr, callback):
+        """
+        Set a breakpoint to receive a callback to the given function when the CPU's program counter reaches the address specified.
+
+        This will allow you to examine or set memory at arbitrary points in execution, not just between ticks.
+
+        The callback should take a single argument which will be the address the CPU is about to execute.  This allows you to register multiple breakpoints to the same callback function.
+
+        Only one callback will be delivered per address - calling this function again with the same address will register the new callback in place of the old one
+
+        Args:
+            addr (int): Emulated address at which the CPU should break and call your code before executing
+            callback (function): The function to call when the CPU breaks - e.g. on_cpu_breakpoint(addr)
+        """
+        self.mb.cpu.set_breakpoint(addr, callback)
+
+    def remove_breakpoint(self, addr):
+        """
+        Removes a previously defined breakpoint such that no callbacks will be made when the program counter reaches the given address.
+
+        If the address was never previously set with set_breakpoint(), this function has no effect.
+
+        Args:
+            addr (int): Emulated address at which the CPU should no longer break
+        """
+        self.mb.cpu.remove_breakpoint(addr)
+
     def send_input(self, event):
         """
         Send a single input to control the emulator. This is both Game Boy buttons and emulator controls.

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -348,13 +348,19 @@ class PyBoy:
 
         This will allow you to examine or set memory at arbitrary points in execution, not just between ticks.
 
-        The callback should take a single argument which will be the address the CPU is about to execute.  This allows you to register multiple breakpoints to the same callback function.
+        The callback should take three positional arguments:
+            1. The address the CPU is about to execute
+            2. The currently selected RAM Bank
+            3. The currently selected ROM Bank
+        This allows you to register multiple breakpoints to the same callback function.
 
-        Only one callback will be delivered per address - calling this function again with the same address will register the new callback in place of the old one
+        Only one callback will be delivered per address -
+        calling this function again with the same address
+        will register the new callback in place of the old one
 
         Args:
             addr (int): Emulated address at which the CPU should break and call your code before executing
-            callback (function): The function to call when the CPU breaks - e.g. on_cpu_breakpoint(addr)
+            callback (function): The function to call when the CPU breaks - e.g. on_cpu_breakpoint(addr, rambank, rombank)
         """
         self.mb.cpu.set_breakpoint(addr, callback)
 


### PR DESCRIPTION
This PR adds breakpoint support to the PyBoy API as client-defined callbacks.  I have a use case for this functionality and thought it might be useful to others as well.

PR is WIP - Looking for feedback as to whether this is appropriate for the project before adding tests etc.  I see there's an ongoing project to add a debugger which would probably supersede this entirely.

Please let me know what you think!

Sample Usage (client code):
```
def on_breakpoint(addr, rambank, rombank):
    print('BREAKPOINT: {} | {} | {}'.format(hex(addr), hex(rambank), hex(rombank)))
    if rombank is 0x1E:
        pyboy.set_memory_value(0xD368, 0xFF)  # Do something useful...


pyboy = PyBoy(gamerom_file=...)
pyboy.set_breakpoint(0x4163, on_breakpoint)

while not pyboy.tick():
    pass
```