### PR TITLE
Fixed hasattr problem in stop and tetris loadstate test

### DIFF
--- a/pyboy/pyboy.pxd
+++ b/pyboy/pyboy.pxd
@@ -29,6 +29,7 @@ cdef class PyBoy:
     cdef list events
     cdef bint quitting
     cdef bint stopped
+    cdef bint initialized
     cdef public str window_title
 
     cdef bint limit_emulationspeed

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -68,6 +68,8 @@ class PyBoy:
         `parser_arguments()` method in the pyboy.plugins.manager module, or by running pyboy --help in the terminal.
         """
 
+        self.initialized = False
+
         for k, v in defaults.items():
             if k not in kwargs:
                 kwargs[k] = kwargs.get(k, defaults[k])
@@ -106,6 +108,7 @@ class PyBoy:
         # Plugins
 
         self.plugin_manager = PluginManager(self, self.mb, kwargs)
+        self.initialized = True
 
     def tick(self):
         """
@@ -227,16 +230,12 @@ class PyBoy:
             save (bool): Specify whether to save the game upon stopping. It will always be saved in a file next to the
                 provided game-ROM.
         """
-        # If __init__ errors, __del__ will call try to call stop() but
-        # self.stopped doesn't exist yet
-        if hasattr(self, "stopped") and not self.stopped:
+        if self.initialized and not self.stopped:
             logger.info("###########################")
             logger.info("# Emulator is turning off #")
             logger.info("###########################")
-            if hasattr(self, "plugin_manager"):
-                self.plugin_manager.stop()
-            if hasattr(self, "mb"):
-                self.mb.stop(save)
+            self.plugin_manager.stop()
+            self.mb.stop(save)
             self.stopped = True
 
     def _cpu_hitrate(self):

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -223,7 +223,7 @@ def test_tetris():
             if frame == 1012:
                 assert not first_brick
 
-            if frame == 1013:
+            if frame == 1014:
                 assert first_brick
 
                 s1 = pyboy.botsupport_manager().sprite(0)
@@ -292,8 +292,11 @@ def test_tetris():
                 pyboy.save_state(state_data)
                 break
 
+    pyboy.send_input(WindowEvent.RELEASE_ARROW_RIGHT)
+    pyboy.tick()
+
     pre_load_game_board_matrix = None
-    for frame in range(1015, 1865):
+    for frame in range(1016, 1865):
         pyboy.tick()
 
         if frame == 1864:
@@ -323,7 +326,7 @@ def test_tetris():
         for _f in [f, state_data]: # Tests both file-written state and in-memory state
             pyboy.load_state(_f) # Reverts memory state to before we changed the Tetromino
             pyboy.tick()
-            for frame in range(1015, 1865):
+            for frame in range(1016, 1865):
                 pyboy.tick()
 
                 if frame == 1864:


### PR DESCRIPTION
Bugfixes for the small-fixes PR--sorry about that. These ones do pass all tests.

* Edited external_api:tetris test to not save a button press
* Changed use of hasattr for explicit intialized flag to fix compatibility with Cython