### PR TITLE
Replace custom scaling logic with SDL_RenderSetLogicalSize

### DIFF
--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -353,6 +353,7 @@ class BaseDebugWindow(PyBoyWindowPlugin):
         self.buf, self.buf0, self.buf_p = make_buffer(width, height)
 
         self._sdlrenderer = sdl2.SDL_CreateRenderer(self._window, -1, sdl2.SDL_RENDERER_ACCELERATED)
+        sdl2.SDL_RenderSetLogicalSize(self._sdlrenderer, width, height)
         self._sdltexturebuffer = sdl2.SDL_CreateTexture(
             self._sdlrenderer, sdl2.SDL_PIXELFORMAT_RGBA8888, sdl2.SDL_TEXTUREACCESS_STATIC, width, height
         )
@@ -362,8 +363,8 @@ class BaseDebugWindow(PyBoyWindowPlugin):
         for event in events:
             if event == WindowEvent._INTERNAL_MOUSE:
                 if event.window_id == self.window_id:
-                    self.hover_x = event.mouse_x // self.scale
-                    self.hover_y = event.mouse_y // self.scale
+                    self.hover_x = event.mouse_x
+                    self.hover_y = event.mouse_y
                 else:
                     self.hover_x = -1
                     self.hover_y = -1
@@ -455,7 +456,7 @@ class TileViewWindow(BaseDebugWindow):
         for event in events:
             if event == WindowEvent._INTERNAL_MOUSE and event.window_id == self.window_id:
                 if event.mouse_button == 0:
-                    tile_x, tile_y = event.mouse_x // self.scale // 8, event.mouse_y // self.scale // 8
+                    tile_x, tile_y = event.mouse_x // 8, event.mouse_y // 8
                     tile_identifier = self.tilemap.tile_identifier(tile_x, tile_y)
                     logger.info(f"Tile clicked on {tile_x}, {tile_y}")
                     marked_tiles.add(
@@ -557,7 +558,7 @@ class TileDataWindow(BaseDebugWindow):
         for event in events:
             if event == WindowEvent._INTERNAL_MOUSE and event.window_id == self.window_id:
                 if event.mouse_button == 0:
-                    tile_x, tile_y = event.mouse_x // self.scale // 8, event.mouse_y // self.scale // 8
+                    tile_x, tile_y = event.mouse_x // 8, event.mouse_y // 8
                     tile_identifier = tile_y * (self.width // 8) + tile_x
                     marked_tiles.add(
                         MarkedTile(tile_identifier=tile_identifier, mark_id="TILE", mark_color=MARK[mark_counter])
@@ -609,7 +610,7 @@ class SpriteWindow(BaseDebugWindow):
         for event in events:
             if event == WindowEvent._INTERNAL_MOUSE and event.window_id == self.window_id:
                 if event.mouse_button == 0:
-                    tile_x, tile_y = event.mouse_x // self.scale // 8, event.mouse_y // self.scale // sprite_height
+                    tile_x, tile_y = event.mouse_x // 8, event.mouse_y // sprite_height
                     sprite_identifier = tile_y * (self.width // 8) + tile_x
                     if sprite_identifier > constants.SPRITES:
                         # Out of bounds

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -160,7 +160,7 @@ class WindowSDL2(PyBoyWindowPlugin):
         )
 
         self._sdlrenderer = sdl2.SDL_CreateRenderer(self._window, -1, sdl2.SDL_RENDERER_ACCELERATED)
-
+        sdl2.SDL_RenderSetLogicalSize(self._sdlrenderer, COLS, ROWS)
         self._sdltexturebuffer = sdl2.SDL_CreateTexture(
             self._sdlrenderer, sdl2.SDL_PIXELFORMAT_RGBA8888, sdl2.SDL_TEXTUREACCESS_STATIC, COLS, ROWS
         )


### PR DESCRIPTION
Instead of translating mouse events by keeping track of the
window's scale, let SDL take care of it.

This commit fixes an issue where mouse clicks and hovers would not
point at correct pixels after resizing a window. Also, now aspect
ratio is maintained after resizing.

This PR is a follow-up from https://github.com/Baekalfen/PyBoy/pull/195 which proposed a more complicated and cumbersome way of achieving the same thing.

<!--

Type an explanation of what feature your code adds or which bug it fixes.

Checklist for pull-requests
---------------------------

  1. The project is licensed under LGPL (see LICENSE.md). When merged, your code will be under the same license.
     So make sure you have read and understand it.
  2. Please coordinate with one of the core developers before making a big pull-request.
     It's a shame to make something big that doesn't fit the project.
  3. Remember to make a separate branch on your fork. This makes it a lot easier for the core developers to help
     getting your pull-request ready.
  4. Install `pip install pre-commit`. This takes care of the formatting rules when you commit your code.
  5. Add tests. We need good pytests for your code. This will help us keep the project stable.
  6. Please don't change the code style, unless it's specifically asked for.

-->

