### PR TITLE
changed cython floats to doubles

### DIFF
--- a/pyboy/plugins/rewind.pxd
+++ b/pyboy/plugins/rewind.pxd
@@ -12,7 +12,7 @@ from pyboy.utils cimport IntIOInterface
 
 
 cdef class Rewind(PyBoyPlugin):
-    cdef float rewind_speed
+    cdef double rewind_speed
     cdef FixedAllocBuffers rewind_buffer
 
 
@@ -42,9 +42,9 @@ cdef class FixedAllocBuffers(IntIOInterface):
     cdef int64_t section_head
     cdef int64_t section_tail
     cdef int64_t section_pointer
-    cdef float avg_section_size
+    cdef double avg_section_size
 
-    @cython.locals(section_size=float)
+    @cython.locals(section_size=double)
     cdef void new(self)
     cdef void commit(self)
     @cython.locals(_=int64_t, abs_frames=int64_t, head=int64_t, tail=int64_t)

--- a/pyboy/plugins/window_open_gl.pxd
+++ b/pyboy/plugins/window_open_gl.pxd
@@ -20,5 +20,5 @@ cdef class WindowOpenGL(PyBoyWindowPlugin):
 
     # TODO: Callbacks don't really work, when Cythonized
     cpdef void _gldraw(self)
-    @cython.locals(scale=float)
+    @cython.locals(scale=double)
     cpdef void _glreshape(self, int, int)

--- a/pyboy/plugins/window_sdl2.pxd
+++ b/pyboy/plugins/window_sdl2.pxd
@@ -20,7 +20,7 @@ cpdef list sdl2_event_pump(list)
 
 cdef class WindowSDL2(PyBoyWindowPlugin):
 
-    cdef float _ftime
+    cdef double _ftime
     cdef dict _key_down
     cdef dict _key_up
     cdef bint fullscreen
@@ -29,5 +29,5 @@ cdef class WindowSDL2(PyBoyWindowPlugin):
     cdef object _sdlrenderer
     cdef object _sdltexturebuffer
 
-    @cython.locals(now=float, delay=cython.int)
+    @cython.locals(now=double, delay=cython.int)
     cdef bint frame_limiter(self, int)

--- a/pyboy/pyboy.pxd
+++ b/pyboy/pyboy.pxd
@@ -12,7 +12,7 @@ from pyboy.utils cimport IntIOWrapper, IntIOInterface
 from pyboy.plugins.manager cimport PluginManager
 
 
-cdef float SPF
+cdef double SPF
 
 cdef class PyBoy:
     cdef Motherboard mb
@@ -41,7 +41,7 @@ cdef class PyBoy:
     cdef list recorded_input
     cdef list external_input
 
-    @cython.locals(t_start=float, t_pre=float, t_tick=float, t_post=float, secs=float)
+    @cython.locals(t_start=double, t_pre=double, t_tick=double, t_post=double, secs=double)
     cpdef bint tick(self)
     cpdef void stop(self, save=*)
 


### PR DESCRIPTION
CPython floats are internally doubles on most modern machines, but in Cython there are distinct float and double types. This PR replaces floats in our `pxd` files to doubles so they match the outputs of the functions they're interacting with.

This also will hopefully fix many of our issues with the frame limiter not working, since the 32-bit floats didn't have enough precision to measure the delay needed.