### PR TITLE
Fix Kirby score variable and game over condition

### DIFF
--- a/pyboy/plugins/game_wrapper_kirby_dream_land.pxd
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.pxd
@@ -14,3 +14,4 @@ cdef class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
     cdef public int health
     cdef public int lives_left
     cdef public int fitness
+    cdef public int _game_over

--- a/pyboy/plugins/game_wrapper_kirby_dream_land.py
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.py
@@ -39,6 +39,8 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         """The health provided by the game"""
         self.lives_left = 0
         """The lives remaining provided by the game"""
+        self._game_over = False
+        """The game over state"""
         self.fitness = 0
         """
         A built-in fitness scoring. Taking score, health, and lives left into account.
@@ -53,10 +55,17 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         self._sprite_cache_invalid = True
 
         self.score = 0
-        for n in range(4):
-            self.score += self.pyboy.get_memory_value(0xD070 + n) * 10**n
+        score_digits = 5
+        for n in range(score_digits):
+            self.score += self.pyboy.get_memory_value(0xD06F + n) * 10**(score_digits-n)
 
+        # Check if game is over
+        prev_health = self.health
         self.health = self.pyboy.get_memory_value(0xD086)
+        if self.lives_left == 0:
+            if prev_health > 0 and self.health == 0:
+                self._game_over = True
+
         self.lives_left = self.pyboy.get_memory_value(0xD089) - 1
 
         if self.game_has_started:
@@ -154,7 +163,7 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         return PyBoyGameWrapper.game_area(self)
 
     def game_over(self):
-        return self.health == 0
+        return self._game_over
 
     def __repr__(self):
         adjust = 4


### PR DESCRIPTION
1) Add one more number of digits (up to 100 000s) and fix the order of score digits from RAM lookup.

2) Workaround and fix game over condition. Due to the way Kirby's Dream Land work, the `game_over()` can't be simply do `return self.lives_left == 0 and self.health == 0`. When Kirby has 1 lives left, in reality, the player can still die twice (having 2 lives). However, when the player die with 1 lives left, their health will remain 0 while their lives left will get set to 0. Although this only happens in a split seconds, it will make the `game_over()` function `return True` even though the player still have 1 more live to go. It seems like `self.lives_left` can't go below 0 as well, that's why I go with this workaround. Not sure if that's the best way or against the practice.

