### PR TITLE
Improve numpy screen grabbing performance

### DIFF
--- a/pyboy/botsupport/screen.pxd
+++ b/pyboy/botsupport/screen.pxd
@@ -3,9 +3,11 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 cimport cython
+cimport numpy as np
 from pyboy.core.mb cimport Motherboard
 
 
 
 cdef class Screen:
     cdef Motherboard mb
+    cpdef np.ndarray[np.uint8_t, ndim=3] screen_ndarray(self)

--- a/pyboy/botsupport/screen.py
+++ b/pyboy/botsupport/screen.py
@@ -113,8 +113,7 @@ class Screen:
         numpy.ndarray:
             Screendata in `ndarray` of bytes with shape (160, 144, 3)
         """
-        return np.frombuffer(self.raw_screen_buffer(), dtype=np.uint8).reshape(ROWS, COLS, 4)[:, :, 1:]
-        # return self.mb.lcd.renderer.screen_buffer_as_ndarray()
+        return np.frombuffer(self.mb.lcd.renderer._screenbuffer_raw, dtype=np.uint8).reshape(ROWS, COLS, 4)[:, :, 1:]
 
     def screen_image(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ pyboy = "pyboy.__main__:main"
 requires = [
     "setuptools>=61.0.0",
     "wheel",
-    "cython>=3.0.0,!=3.0.4; platform_python_implementation == 'CPython'"
+    "cython>=3.0.0,!=3.0.4; platform_python_implementation == 'CPython'",
+    "numpy",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import platform
 import sys
 from multiprocessing import cpu_count
 
+import numpy as np
 from Cython.Build import cythonize
 from Cython.Distutils import build_ext as _build_ext
 from setuptools import Extension, setup
@@ -38,6 +39,7 @@ class build_ext(_build_ext):
                 src.split(".")[0].replace(os.sep, "."),
                 [src],
                 extra_compile_args=cflags,
+                include_dirs=[np.get_include()],
             ), list(py_pxd_files)
         )
         self.distribution.ext_modules = cythonize(


### PR DESCRIPTION
This PR improves PyBoy's speed when using `botsupport_manager().screen().screen_ndarray()`. From personal testing with [py-spy](https://github.com/benfred/py-spy), these changes decreased the time spent in `screen_ndarray()` from ~6% to ~2%.