### PR TITLE
Fix a couple performance hints

### DIFF
--- a/pyboy/core/ram.pxd
+++ b/pyboy/core/ram.pxd
@@ -3,12 +3,15 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
+cimport cython
 from libc.stdint cimport uint8_t
 from pyboy.utils cimport IntIOInterface
 
 
 cdef class RAM:
+    @cython.locals(n=int)
     cdef void save_state(self, IntIOInterface) noexcept
+    @cython.locals(n=int)
     cdef void load_state(self, IntIOInterface, int) noexcept
 
     cdef uint8_t[:] internal_ram0 # Dynamic size for DMG/CGB


### PR DESCRIPTION
Cython reports the following performance hints:
```
  performance hint: pyboy/core/ram.py:29:35: Index should be typed for more efficient access
  performance hint: pyboy/core/ram.py:39:39: Index should be typed for more efficient access
  performance hint: pyboy/core/ram.py:52:31: Index should be typed for more efficient access
  performance hint: pyboy/plugins/debug.py:560:67: Index should be typed for more efficient access
  performance hint: pyboy/plugins/debug.py:575:45: Index should be typed for more efficient access
  performance hint: pyboy/plugins/debug.py:815:27: Index should be typed for more efficient access
 ```

Not sure why the ones in `debug.py` are happening and the first ram hint is in `__init__`. But I took care of the other two at least.