### PR TITLE
Use integer subtraction over modulo arithmetic for a slight speed boost

### DIFF
--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -154,8 +154,8 @@ class LCD:
                 if self._STAT._mode == 2: # Searching OAM
                     if self.LY == 153:
                         self.LY = 0
-                        self.clock %= FRAME_CYCLES
-                        self.clock_target %= FRAME_CYCLES
+                        self.clock -= FRAME_CYCLES
+                        self.clock_target -= FRAME_CYCLES
                     else:
                         self.LY += 1
 
@@ -192,7 +192,7 @@ class LCD:
             # See also `self.set_lcdc`
             if self.clock >= FRAME_CYCLES:
                 self.frame_done = True
-                self.clock %= FRAME_CYCLES
+                self.clock -= FRAME_CYCLES
 
                 # Renderer
                 self.renderer.blank_screen(self)

--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -154,8 +154,10 @@ class LCD:
                 if self._STAT._mode == 2: # Searching OAM
                     if self.LY == 153:
                         self.LY = 0
-                        self.clock -= FRAME_CYCLES
-                        self.clock_target -= FRAME_CYCLES
+                        if self.clock >= FRAME_CYCLES:
+                            self.clock -= FRAME_CYCLES
+                        if self.clock_target >= FRAME_CYCLES:
+                            self.clock_target -= FRAME_CYCLES
                     else:
                         self.LY += 1
 

--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -154,10 +154,8 @@ class LCD:
                 if self._STAT._mode == 2: # Searching OAM
                     if self.LY == 153:
                         self.LY = 0
-                        if self.clock >= FRAME_CYCLES:
-                            self.clock -= FRAME_CYCLES
-                        if self.clock_target >= FRAME_CYCLES:
-                            self.clock_target -= FRAME_CYCLES
+                        self.clock -= FRAME_CYCLES
+                        self.clock_target -= FRAME_CYCLES
                     else:
                         self.LY += 1
 


### PR DESCRIPTION
I doubt self.clock or self.clock_target ever exceeds 2*FRAME_CYCLES. In testing, this change showed a 3-6% speed increase assuming the screen is being rendered every tick.