### PR TITLE
Change keybindings for sdl2

### DIFF
--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -95,6 +95,10 @@ else:
     CONTROLLER_UP = {}
 # yapf: enable
 
+def set_keybinding(sdl2_key, press_window_event, release_window_event):
+    if sdl2:
+        KEY_DOWN[sdl2_key] = press_window_event
+        KEY_UP[sdl2_key] = release_window_event
 
 def sdl2_event_pump(events):
     global _sdlcontroller


### PR DESCRIPTION
Added feature to change the sdl2 keybindings as suggested by [this issue](https://github.com/Baekalfen/PyBoy/issues/249).

Usage:
```python
from pyboy.plugins.window_sdl2 import set_keybinding

set_keybinding(sdl2.SDLK_w, WindowEvent.PRESS_ARROW_UP, WindowEvent.RELEASE_ARROW_UP)
set_keybinding(sdl2.SDLK_s, WindowEvent.PRESS_ARROW_DOWN, WindowEvent.RELEASE_ARROW_DOWN)
set_keybinding(sdl2.SDLK_a, WindowEvent.PRESS_ARROW_LEFT, WindowEvent.RELEASE_ARROW_LEFT)
set_keybinding(sdl2.SDLK_d, WindowEvent.PRESS_ARROW_RIGHT, WindowEvent.RELEASE_ARROW_RIGHT)
```

