### PR TITLE
Only show frame-limiting warning when calling set_emulation_speed

### DIFF
--- a/pyboy/plugins/window_dummy.py
+++ b/pyboy/plugins/window_dummy.py
@@ -18,9 +18,6 @@ class WindowDummy(PyBoyWindowPlugin):
             return
 
         pyboy._rendering(False)
-        logger.warning(
-            'This window type does not support frame-limiting. `pyboy.set_emulation_speed(...)` will have no effect, as it\'s always running at full speed.'
-        )
 
     def enabled(self):
         return self.pyboy_argv.get("window_type") == "dummy"

--- a/pyboy/plugins/window_headless.py
+++ b/pyboy/plugins/window_headless.py
@@ -17,10 +17,6 @@ class WindowHeadless(PyBoyWindowPlugin):
         if not self.enabled():
             return
 
-        logger.warning(
-            'This window type does not support frame-limiting. `pyboy.set_emulation_speed(...)` will have no effect, as it\'s always running at full speed.'
-        )
-
     def enabled(self):
         return self.pyboy_argv.get("window_type") == "headless"
 

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -485,6 +485,17 @@ class PyBoy:
         Args:
             target_speed (int): Target emulation speed as multiplier of real-time.
         """
+        if self.initialized:
+            unsupported_window_types_enabled = [
+                self.plugin_manager.window_dummy_enabled,
+                self.plugin_manager.window_headless_enabled,
+                self.plugin_manager.window_open_gl_enabled
+            ]
+            if any(unsupported_window_types_enabled):
+                logger.warning(
+                    'This window type does not support frame-limiting. `pyboy.set_emulation_speed(...)` will have no effect, as it\'s always running at full speed.'
+                )
+
         if target_speed > 5:
             logger.warning("The emulation speed might not be accurate when speed-target is higher than 5")
         self.target_emulationspeed = target_speed


### PR DESCRIPTION
tackling https://github.com/Baekalfen/PyBoy/issues/260

remove warnings from the individual plugins, add warning into ``set_emulation_speed`` after first initialization if not supported with current window_type
<!--

Checklist for pull-requests
---------------------------

  1. The project is licensed under LGPL (see LICENSE.md). When merged, your code will be under the same license.
     So make sure you have read and understand it.
  2. Please coordinate with one of the core developers before making a big pull-request.
     It's a shame to make something big that doesn't fit the project.
  3. Remember to make a separate branch on your fork. This makes it a lot easier for the core developers to help
     getting your pull-request ready.
  4. Install `pip install pre-commit`. This takes care of the formatting rules when you commit your code.
  5. Add tests. We need good pytests for your code. This will help us keep the project stable.
  6. Please don't change the code style, unless it's specifically asked for.

-->

