### PR TITLE
Update Sprite palette number to support CGB

### DIFF
--- a/pyboy/api/sprite.pxd
+++ b/pyboy/api/sprite.pxd
@@ -19,7 +19,7 @@ cdef class Sprite:
     cdef readonly bint attr_obj_bg_priority
     cdef readonly bint attr_y_flip
     cdef readonly bint attr_x_flip
-    cdef readonly bint attr_palette_number
+    cdef readonly int attr_palette_number
     cdef readonly tuple shape
     cdef readonly list tiles
     cdef readonly bint on_screen

--- a/pyboy/api/sprite.pxd
+++ b/pyboy/api/sprite.pxd
@@ -20,6 +20,7 @@ cdef class Sprite:
     cdef readonly bint attr_y_flip
     cdef readonly bint attr_x_flip
     cdef readonly int attr_palette_number
+    cdef readonly bint attr_cgb_bank_number
     cdef readonly tuple shape
     cdef readonly list tiles
     cdef readonly bint on_screen

--- a/pyboy/api/sprite.py
+++ b/pyboy/api/sprite.py
@@ -117,7 +117,7 @@ class Sprite:
         """
 
         if self.mb.cgb:
-            self.attr_palette_number = attr & 0x3
+            self.attr_palette_number = attr & 0b111
         else:
             self.attr_palette_number = _bit(attr, 4)
         """

--- a/pyboy/api/sprite.py
+++ b/pyboy/api/sprite.py
@@ -116,12 +116,7 @@ class Sprite:
             The state of the bit in the attributes lookup.
         """
 
-        if self.mb.cgb:
-            self.attr_palette_number = attr & 0b111
-            self.attr_cgb_bank_number = _bit(attr, 3)
-        else:
-            self.attr_palette_number = _bit(attr, 4)
-            self.attr_cgb_bank_number = 0
+        self.attr_palette_number = 0
         """
         To better understand this values, look in the [Pan Docs: VRAM Sprite Attribute Table
         (OAM)](https://gbdev.io/pandocs/OAM.html).
@@ -131,6 +126,23 @@ class Sprite:
         int:
             The state of the bit(s) in the attributes lookup.
         """
+
+        self.attr_cgb_bank_number = 0
+        """
+        To better understand this values, look in the [Pan Docs: VRAM Sprite Attribute Table
+        (OAM)](https://gbdev.io/pandocs/OAM.html).
+
+        Returns
+        -------
+        bool:
+            The state of the bit in the attributes lookup.
+        """
+
+        if self.mb.cgb:
+            self.attr_palette_number = attr & 0b111
+            self.attr_cgb_bank_number = _bit(attr, 3)
+        else:
+            self.attr_palette_number = _bit(attr, 4)
 
         LCDC = LCDCRegister(self.mb.getitem(LCDC_OFFSET))
         sprite_height = 16 if LCDC._get_sprite_height() else 8

--- a/pyboy/api/sprite.py
+++ b/pyboy/api/sprite.py
@@ -118,8 +118,10 @@ class Sprite:
 
         if self.mb.cgb:
             self.attr_palette_number = attr & 0b111
+            self.attr_cgb_bank_number = _bit(attr, 3)
         else:
             self.attr_palette_number = _bit(attr, 4)
+            self.attr_cgb_bank_number = 0
         """
         To better understand this values, look in the [Pan Docs: VRAM Sprite Attribute Table
         (OAM)](https://gbdev.io/pandocs/OAM.html).

--- a/pyboy/api/sprite.py
+++ b/pyboy/api/sprite.py
@@ -116,15 +116,18 @@ class Sprite:
             The state of the bit in the attributes lookup.
         """
 
-        self.attr_palette_number = _bit(attr, 4)
+        if self.mb.cgb:
+            self.attr_palette_number = attr & 0x3
+        else:
+            self.attr_palette_number = _bit(attr, 4)
         """
         To better understand this values, look in the [Pan Docs: VRAM Sprite Attribute Table
         (OAM)](https://gbdev.io/pandocs/OAM.html).
 
         Returns
         -------
-        bool:
-            The state of the bit in the attributes lookup.
+        int:
+            The state of the bit(s) in the attributes lookup.
         """
 
         LCDC = LCDCRegister(self.mb.getitem(LCDC_OFFSET))


### PR DESCRIPTION
I noticed that the palette in the sprite object only supported DMG mode as bit 4 is unused in CGB mode and instead uses bits 2-0 for the palette options

https://gbdev.io/pandocs/OAM