### PR TITLE
Fix get() in LCD register FF69 to return 8 bits. Fixes #224

### DIFF
--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -977,7 +977,10 @@ class PaletteColorRegister:
         self.index_reg.shouldincrement()
 
     def get(self):
-        return self.palette_mem[self.index_reg.getindex()]
+        if self.index_reg.hl:
+            return (self.palette_mem[self.index_reg.getindex()] & 0xFF00) >> 8
+        else:
+            return self.palette_mem[self.index_reg.getindex()] & 0x00FF
 
     def getcolor(self, paletteindex, colorindex):
         # Each palette = 8 bytes or 4 colors of 2 bytes


### PR DESCRIPTION
The LCD register get method was not checking the value of `.hl` and returning a byte; it returned the whole 16-bit register. This was either sending the wrong data to the CPU or promoting registers to 16 bits depending on whether PyBoy was compiled or not. 