### PR TITLE
initialize hooks for use in wrapper

### DIFF
--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -270,6 +270,8 @@ class PyBoy:
             Object for handling plugins in PyBoy
         """
 
+        self._hooks = {}
+
         self.game_wrapper = self._plugin_manager.gamewrapper()
         """
         Provides an instance of a game-specific or generic wrapper. The game is detected by the cartridge's hard-coded
@@ -292,7 +294,6 @@ class PyBoy:
             A game-specific wrapper object.
         """
 
-        self._hooks = {}
         self.initialized = True
 
     def _tick(self, render):


### PR DESCRIPTION
Moved pyboy._hooks to be initialized before game wrappers so the game wrappers can make hooks during initialization 