### PR TITLE
Move hook initialization

### DIFF
--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -272,8 +272,6 @@ class PyBoy:
             Object for handling plugins in PyBoy
         """
 
-        self._hooks = {}
-
         self.game_wrapper = self._plugin_manager.gamewrapper()
         """
         Provides an instance of a game-specific or generic wrapper. The game is detected by the cartridge's hard-coded

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -270,6 +270,8 @@ class PyBoy:
             Object for handling plugins in PyBoy
         """
 
+        self._hooks = {}
+
         self.game_wrapper = self._plugin_manager.gamewrapper()
         """
         Provides an instance of a game-specific or generic wrapper. The game is detected by the cartridge's hard-coded
@@ -292,7 +294,6 @@ class PyBoy:
             A game-specific wrapper object.
         """
 
-        self._hooks = {}
         self.initialized = True
 
     def _tick(self, render):

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -262,6 +262,8 @@ class PyBoy:
             Game title
         """
 
+        self._hooks = {}
+
         self._plugin_manager = PluginManager(self, self.mb, kwargs)
         """
         Returns
@@ -269,8 +271,6 @@ class PyBoy:
         `pyboy.plugins.manager.PluginManager`:
             Object for handling plugins in PyBoy
         """
-
-        self._hooks = {}
 
         self.game_wrapper = self._plugin_manager.gamewrapper()
         """


### PR DESCRIPTION
This adjusts the initialization to be before the plugin manager as well. I made a mistake in my last PR and didn't move it to the right line, my apologies.