### PR TITLE
Fix wrong addressing in the debugging memory view

### DIFF
--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -313,7 +313,7 @@ class Debug(PyBoyWindowPlugin):
                         print(f"{bank:02X}:{addr:04X} {label}")
             elif cmd == "bl":
                 for bank, addr in self.mb.breakpoints_list:
-                    print(f"{bank:02X}:{addr:04X} {self.rom_symbols.get(bank, {}).get(addr, "")}")
+                    print(f"{bank:02X}:{addr:04X} {self.rom_symbols.get(bank, {}).get(addr, '')}")
             elif cmd == "b" or cmd.startswith("b "):
                 if cmd.startswith("b "):
                     _, command = cmd.split(" ", 1)
@@ -874,11 +874,11 @@ class MemoryWindow(BaseDebugWindow):
         self.dst.y = y
         for i, c in enumerate(text):
             if not 0 <= c < 256:
-                logger.warn(f"Invalid character {c} in {bytes(text).decode("cp437")}") # This may error too...
+                logger.warn(f"Invalid character {c} in {bytes(text).decode('cp437')}") # This may error too...
                 c = 0
             self.src.y = 16 * c
             if self.dst.x > self.width - 8:
-                logger.warn(f"Text overrun while printing {bytes(text).decode("cp437")}")
+                logger.warn(f"Text overrun while printing {bytes(text).decode('cp437')}")
                 break
             sdl2.SDL_RenderCopy(self._sdlrenderer, self.font_texture, self.src, self.dst)
             self.dst.x += 8

--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -313,7 +313,7 @@ class Debug(PyBoyWindowPlugin):
                         print(f"{bank:02X}:{addr:04X} {label}")
             elif cmd == "bl":
                 for bank, addr in self.mb.breakpoints_list:
-                    print(f"{bank:02X}:{addr:04X} {self.rom_symbols.get(bank, {}).get(addr, '')}")
+                    print(f"{bank:02X}:{addr:04X} {self.rom_symbols.get(bank, {}).get(addr, "")}")
             elif cmd == "b" or cmd.startswith("b "):
                 if cmd.startswith("b "):
                     _, command = cmd.split(" ", 1)
@@ -846,11 +846,11 @@ class MemoryWindow(BaseDebugWindow):
 
     def write_addresses(self):
         header = (f"Memory from 0x{self.start_address:04X} "
-                  f"to 0x{self.start_address+0x3FF:04X}").encode("cp437")
+                  f"to 0x{self.start_address+0x1FF:04X}").encode("cp437")
         for x in range(28):
             self.text_buffer[1, x + 2] = header[x]
         for y in range(32):
-            addr = f"0x{self.start_address + (0x20*y):04X}".encode("cp437")
+            addr = f"0x{self.start_address + (0x10*y):04X}".encode("cp437")
             for x in range(6):
                 self.text_buffer[y + 3, x + 2] = addr[x]
 
@@ -874,11 +874,11 @@ class MemoryWindow(BaseDebugWindow):
         self.dst.y = y
         for i, c in enumerate(text):
             if not 0 <= c < 256:
-                logger.warn(f"Invalid character {c} in {bytes(text).decode('cp437')}") # This may error too...
+                logger.warn(f"Invalid character {c} in {bytes(text).decode("cp437")}") # This may error too...
                 c = 0
             self.src.y = 16 * c
             if self.dst.x > self.width - 8:
-                logger.warn(f"Text overrun while printing {bytes(text).decode('cp437')}")
+                logger.warn(f"Text overrun while printing {bytes(text).decode("cp437")}")
                 break
             sdl2.SDL_RenderCopy(self._sdlrenderer, self.font_texture, self.src, self.dst)
             self.dst.x += 8
@@ -891,7 +891,7 @@ class MemoryWindow(BaseDebugWindow):
 
     def _scroll_view(self, movement):
         self.start_address += movement
-        self.start_address = max(0, min(self.start_address, 0x10000 - 0x400))
+        self.start_address = max(0, min(self.start_address, 0x10000 - 0x200))
         # if self.start_address + 0x400 > 0x10000:
         #     self.start_address = 0x10000 - 0x400
         # if self.start_address < 0:


### PR DESCRIPTION
I noticed that there is something wrong with the addressing of the debugging memory view. In this view, there are 16 values in each row, thus the address should increment by 0x10 each time. However, in the code, the address is incremented by 0x20, which leads to wrong results. This also causes the highest 0x200 bytes of the memory is not able to be displayed. Please refer to the attached image and file changes for more details.

![illustration of the fix](https://i.miji.bid/2024/02/27/3c94fd22dedb89e0258b6599433a087b.png)