### PR TITLE
fix pokemon tilemap wapper for 2.0

### DIFF
--- a/pyboy/plugins/game_wrapper_pokemon_gen1.py
+++ b/pyboy/plugins/game_wrapper_pokemon_gen1.py
@@ -44,9 +44,8 @@ class GameWrapperPokemonGen1(PyBoyGameWrapper):
 
     def _get_screen_background_tilemap(self):
         ### SIMILAR TO CURRENT pyboy.game_wrapper.game_area(), BUT ONLY FOR BACKGROUND TILEMAP, SO NPC ARE SKIPPED
-        bsm = self.pyboy.botsupport_manager()
-        ((scx, scy), (wx, wy)) = bsm.screen().tilemap_position()
-        tilemap = np.array(bsm.tilemap_background[:, :])
+        ((scx, scy), (wx, wy)) = self.pyboy.screen.get_tilemap_position()
+        tilemap = np.array(self.pyboy.tilemap_background[:, :])
         return np.roll(np.roll(tilemap, -scy // 8, axis=0), -scx // 8, axis=1)[:18, :20]
 
     def _get_screen_walkable_matrix(self):


### PR DESCRIPTION
<!--

Fix Pokemon wrapper Screen Tile helper method for 2.0:

    2.0 introduced a new method for getting the screen tile map, this
    commit simply swaps the old 1.x API for the new 2.x API per API
    doc: https://docs.pyboy.dk/api/screen.html#pyboy.api.screen.
    Screen.get_tilemap_position

FYI, the screen methods is a bit confusing to me, specifically this part in the screen doc:

>     If you're making an AI or bot, it's highly recommended to _not_ use this class for detecting objects on the screen.
>     It's much more efficient to use `pyboy.PyBoy.tilemap_background`, `pyboy.PyBoy.tilemap_window`, and `pyboy.PyBoy.get_sprite` instead.
> 

It seems like `self.pyboy.screen.get_tilemap_position()` is still required though? Is this still the most efficient way to get the tilemap then? Otherwise, hope it helps.

