### PR TITLE
Small fix to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ for _ in range(target//15):
 <td >
 
 ```python
-pyboy.tick(target)
+for _ in range(target):
+    pyboy.tick(render=False)
 
 ```
 </td>

--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ for _ in range(target//15):
 <td >
 
 ```python
-for _ in range(target):
-    pyboy.tick(render=False)
+pyboy.tick(target, False)
 
 ```
 </td>


### PR DESCRIPTION
Updated no rendering example from
```python
pyboy.tick(target) # render=False not set

```
to
```python
for _ in range(target):
    pyboy.tick(render=False)

```