### PR TITLE
GameWrapper: Add second Tile for Sprites using two Tiles in the game area matrix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,10 @@
 exclude: (opcodes.py|manager.py|manager.pxd)
 repos:
-- repo: https://github.com/myint/unify
-  rev: v0.5
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.8.0
   hooks:
-    - id: unify
-      args: [--quote, '"', --in-place]
-      language: python
-      types: [python]
-- repo: https://github.com/google/yapf
-  rev: 'v0.40.2'
-  hooks:
-  - id: yapf
-    additional_dependencies: [toml]
-- repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
+    # Run the linter.
+    - id: ruff
+      args: [--select, I, --fix]
+    # Run the formatter.
+    - id: ruff-format

--- a/extras/bootrom/logo_to_tiles.py
+++ b/extras/bootrom/logo_to_tiles.py
@@ -54,11 +54,11 @@ xxx.....
 .xx..xx.
 .xxxxxx.
 .xxxxx..
-........"""
+........""",
 }
 
 asm_out = ".logo:\n"
-for name in ["P1", "P2", "Y1", "B2", "O", "Y2"]: # Order is important, so we can't iterate on TILES
+for name in ["P1", "P2", "Y1", "B2", "O", "Y2"]:  # Order is important, so we can't iterate on TILES
     rows = [int(f"0b{row.replace('.', '0').replace('x', '1')}", base=2) for row in TILES[name].split()]
     asm_out += f".{name}\n"
     asm_out += "    DB "

--- a/extras/examples/gamewrapper_kirby.py
+++ b/extras/examples/gamewrapper_kirby.py
@@ -10,8 +10,8 @@ import sys
 file_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, file_path + "/../..")
 
-from pyboy import PyBoy # isort:skip
-from pyboy.utils import WindowEvent # isort:skip
+from pyboy import PyBoy  # isort:skip
+from pyboy.utils import WindowEvent  # isort:skip
 
 # Check if the ROM is given through argv
 if len(sys.argv) > 1:
@@ -33,7 +33,7 @@ assert kirby.lives_left == 4
 assert kirby.health == 6
 
 pyboy.button_press("right")
-for _ in range(280): # Walk for 280 ticks
+for _ in range(280):  # Walk for 280 ticks
     # We tick one frame at a time to still render the screen for every step
     pyboy.tick(1, True)
 

--- a/extras/examples/gamewrapper_mario.py
+++ b/extras/examples/gamewrapper_mario.py
@@ -10,8 +10,8 @@ import sys
 file_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, file_path + "/../..")
 
-from pyboy import PyBoy # isort:skip
-from pyboy.utils import WindowEvent # isort:skip
+from pyboy import PyBoy  # isort:skip
+from pyboy.utils import WindowEvent  # isort:skip
 
 # Check if the ROM is given through argv
 if len(sys.argv) > 1:

--- a/extras/examples/gamewrapper_tetris.py
+++ b/extras/examples/gamewrapper_tetris.py
@@ -10,8 +10,8 @@ import sys
 file_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, file_path + "/../..")
 
-from pyboy import PyBoy # isort:skip
-from pyboy.utils import WindowEvent # isort:skip
+from pyboy import PyBoy  # isort:skip
+from pyboy.utils import WindowEvent  # isort:skip
 
 # Check if the ROM is given through argv
 if len(sys.argv) > 1:
@@ -26,7 +26,7 @@ pyboy.set_emulation_speed(0)
 assert pyboy.cartridge_title == "TETRIS"
 
 tetris = pyboy.game_wrapper
-tetris.start_game(timer_div=0x00) # The timer_div works like a random seed in Tetris
+tetris.start_game(timer_div=0x00)  # The timer_div works like a random seed in Tetris
 
 tetromino_at_0x00 = tetris.next_tetromino()
 assert tetromino_at_0x00 == "O", tetris.next_tetromino()
@@ -40,11 +40,11 @@ assert tetris.next_tetromino() == tetromino_at_0x00, tetris.next_tetromino()
 
 blank_tile = 47
 first_brick = False
-for frame in range(1000): # Enough frames for the test. Otherwise do: `while pyboy.tick():`
+for frame in range(1000):  # Enough frames for the test. Otherwise do: `while pyboy.tick():`
     pyboy.tick(1, True)
 
     # The playing "technique" is just to move the Tetromino to the right.
-    if frame % 2 == 0: # Even frames to let PyBoy release the button on odd frames
+    if frame % 2 == 0:  # Even frames to let PyBoy release the button on odd frames
         pyboy.button("right")
 
     # Illustrating how we can extract the game board quite simply. This can be used to read the tile identifiers.
@@ -74,7 +74,7 @@ assert tetris.next_tetromino() == tetromino_at_0x00, tetris.next_tetromino()
 # After reseting, we should have a clean game area
 assert all(filter(lambda x: x != blank_tile, game_area[-1, :]))
 
-tetris.reset_game(timer_div=0x55) # The timer_div works like a random seed in Tetris
+tetris.reset_game(timer_div=0x55)  # The timer_div works like a random seed in Tetris
 assert tetris.next_tetromino() != tetromino_at_0x00, tetris.next_tetromino()
 
 # Testing that it defaults to random Tetrominos
@@ -82,6 +82,6 @@ selection = set()
 for _ in range(10):
     tetris.reset_game()
     selection.add(tetris.next_tetromino())
-assert len(selection) > 1 # If it's random, we will see more than one kind
+assert len(selection) > 1  # If it's random, we will see more than one kind
 
 pyboy.stop()

--- a/extras/font/makefont.py
+++ b/extras/font/makefont.py
@@ -40,7 +40,7 @@ def main(bdffile, unifile, *args):
                     chars[int(newchar.meta["ENCODING"])] = newchar
                     break
                 else:
-                    newchar.meta[line[0]] = (line[1:] if len(line) > 2 else line[1])
+                    newchar.meta[line[0]] = line[1:] if len(line) > 2 else line[1]
 
     chars437 = [chars[n] for n in uni]
     with open("font.txt", "w") as f:
@@ -56,7 +56,7 @@ The full source code for the Terminus font is available at
 
 -----------------------------------------------------------
 """,
-            file=f
+            file=f,
         )
 
         with open("OFL.txt", "r") as licensefile:
@@ -67,7 +67,7 @@ The full source code for the Terminus font is available at
         print("BASE64DATA:", file=f)
         blob = b64encode(zlib.compress(b"".join((b for c in chars437 for b in c.bits))))
         for n in range(0, len(blob), 72):
-            print(blob[n:n + 72].decode(), file=f)
+            print(blob[n : n + 72].decode(), file=f)
 
     if "--bitmap" in args:
         if not Image:
@@ -77,7 +77,7 @@ The full source code for the Terminus font is available at
             for row in range(16):
                 for pixrow in range(16):
                     for col in range(16):
-                        buf += chars437[16*row + col].bits[pixrow]
+                        buf += chars437[16 * row + col].bits[pixrow]
 
             image = Image.frombytes("1", (128, 256), bytes(buf))
             image.save("fontsheet.bmp")

--- a/pyboy/__main__.py
+++ b/pyboy/__main__.py
@@ -48,13 +48,13 @@ parser.add_argument(
     default=defaults["log_level"],
     type=str,
     choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
-    help="Set logging level"
+    help="Set logging level",
 )
 parser.add_argument(
     "--color-palette",
     type=color_tuple,
     default=defaults["color_palette"],
-    help=('Four comma seperated, hexadecimal, RGB values for colors (i.e. "FFFFFF,999999,555555,000000")')
+    help=('Four comma seperated, hexadecimal, RGB values for colors (i.e. "FFFFFF,999999,555555,000000")'),
 )
 parser.add_argument(
     "--cgb-color-palette",
@@ -62,7 +62,7 @@ parser.add_argument(
     default=defaults["cgb_color_palette"],
     help=(
         'Three sets of four comma seperated, hexadecimal, RGB values for colors in the order of: background, obj0, obj1 (i.e. "FFFFFF,7BFF31,0063C5,000000,FFFFFF,FF8484,FF8484,000000,FFFFFF,FF8484,FF8484,000000")'
-    )
+    ),
 )
 parser.add_argument(
     "-l",
@@ -74,7 +74,7 @@ parser.add_argument(
     help=(
         "Load state from file. If filepath is specified, it will load the given path. Otherwise, it will automatically "
         "locate a saved state next to the ROM file."
-    )
+    ),
 )
 parser.add_argument(
     "-w",
@@ -82,7 +82,7 @@ parser.add_argument(
     default=defaults["window"],
     type=str,
     choices=["SDL2", "OpenGL", "null"],
-    help="Specify window-type to use"
+    help="Specify window-type to use",
 )
 parser.add_argument("-s", "--scale", default=defaults["scale"], type=int, help="The scaling multiplier for the window")
 parser.add_argument("--sound", action="store_true", help="Enable sound (beta)")
@@ -90,7 +90,7 @@ parser.add_argument("--no-renderer", action="store_true", help="Disable renderin
 parser.add_argument(
     "--gameshark",
     type=str,
-    help="Add GameShark cheats on start-up. Add multiple by comma separation (i.e. '010138CD, 01033CD1')"
+    help="Add GameShark cheats on start-up. Add multiple by comma separation (i.e. '010138CD, 01033CD1')",
 )
 
 gameboy_type_parser = parser.add_mutually_exclusive_group()

--- a/pyboy/api/gameshark.py
+++ b/pyboy/api/gameshark.py
@@ -19,7 +19,7 @@ class GameShark:
         self.enabled = False
 
     def _convert_cheat(self, gameshark_code):
-        '''
+        """
         A GameShark code for these consoles is written in the format ttvvaaaa. tt specifies the type, which is usually 01.
         vv specifies the hexadecimal value the code will write into the game's memory. aaaa specifies the memory address
         that will be modified, with the low byte first (e.g. address C056 is written as 56C0).
@@ -32,18 +32,18 @@ class GameShark:
         https://doc.kodewerx.org/hacking_gb.html
 
         There seems to be conflicting information about the presence of other types than 01.
-        '''
+        """
         # Check if the input cheat code has the correct length (8 characters)
         if len(gameshark_code) != 8:
             raise ValueError("Invalid cheat code length. Cheat code must be 8 characters long.")
 
         # Extract components from the cheat code
         _type = int(gameshark_code[:2], 16)
-        value = int(gameshark_code[2:4], 16) # Convert hexadecimal value to an integer
-        unconverted_address = gameshark_code[4:] # Ex:   1ED1
-        lower = unconverted_address[:2] # Ex:  1E
-        upper = unconverted_address[2:] # Ex:  D1
-        address_converted = upper + lower # Ex: 0xD11E   # Converting to Ram Readable address
+        value = int(gameshark_code[2:4], 16)  # Convert hexadecimal value to an integer
+        unconverted_address = gameshark_code[4:]  # Ex:   1ED1
+        lower = unconverted_address[:2]  # Ex:  1E
+        upper = unconverted_address[2:]  # Ex:  D1
+        address_converted = upper + lower  # Ex: 0xD11E   # Converting to Ram Readable address
         address = int(address_converted, 16)
 
         if not 0x8000 <= address:

--- a/pyboy/api/memory_scanner.py
+++ b/pyboy/api/memory_scanner.py
@@ -5,6 +5,7 @@ from pyboy.utils import bcd_to_dec
 
 class StandardComparisonType(Enum):
     """Enumeration for defining types of comparisons that do not require a previous value."""
+
     EXACT = 1
     LESS_THAN = 2
     GREATER_THAN = 3
@@ -14,6 +15,7 @@ class StandardComparisonType(Enum):
 
 class DynamicComparisonType(Enum):
     """Enumeration for defining types of comparisons that require a previous value."""
+
     UNCHANGED = 1
     CHANGED = 2
     INCREASED = 3
@@ -23,12 +25,14 @@ class DynamicComparisonType(Enum):
 
 class ScanMode(Enum):
     """Enumeration for defining scanning modes."""
+
     INT = 1
     BCD = 2
 
 
-class MemoryScanner():
+class MemoryScanner:
     """A class for scanning memory within a given range."""
+
     def __init__(self, pyboy):
         self.pyboy = pyboy
         self._memory_cache = {}
@@ -42,7 +46,7 @@ class MemoryScanner():
         standard_comparison_type=StandardComparisonType.EXACT,
         value_type=ScanMode.INT,
         byte_width=1,
-        byteorder="little"
+        byteorder="little",
     ):
         """
         This function scans a specified range of memory for a target value from the `start_addr` to the `end_addr` (both included).
@@ -69,9 +73,11 @@ class MemoryScanner():
         """
         self._memory_cache = {}
         self._memory_cache_byte_width = byte_width
-        for addr in range(start_addr, end_addr - (byte_width-1) + 1): # Adjust the loop to prevent reading past end_addr
+        for addr in range(
+            start_addr, end_addr - (byte_width - 1) + 1
+        ):  # Adjust the loop to prevent reading past end_addr
             # Read multiple bytes based on byte_width and byteorder
-            value_bytes = self.pyboy.memory[addr:addr + byte_width]
+            value_bytes = self.pyboy.memory[addr : addr + byte_width]
             value = int.from_bytes(value_bytes, byteorder)
 
             if value_type == ScanMode.BCD:
@@ -113,29 +119,29 @@ class MemoryScanner():
         """
         for addr, value in self._memory_cache.copy().items():
             current_value = int.from_bytes(
-                self.pyboy.memory[addr:addr + self._memory_cache_byte_width], byteorder=byteorder
+                self.pyboy.memory[addr : addr + self._memory_cache_byte_width], byteorder=byteorder
             )
-            if (dynamic_comparison_type == DynamicComparisonType.UNCHANGED):
+            if dynamic_comparison_type == DynamicComparisonType.UNCHANGED:
                 if value != current_value:
                     self._memory_cache.pop(addr)
                 else:
                     self._memory_cache[addr] = current_value
-            elif (dynamic_comparison_type == DynamicComparisonType.CHANGED):
+            elif dynamic_comparison_type == DynamicComparisonType.CHANGED:
                 if value == current_value:
                     self._memory_cache.pop(addr)
                 else:
                     self._memory_cache[addr] = current_value
-            elif (dynamic_comparison_type == DynamicComparisonType.INCREASED):
+            elif dynamic_comparison_type == DynamicComparisonType.INCREASED:
                 if value >= current_value:
                     self._memory_cache.pop(addr)
                 else:
                     self._memory_cache[addr] = current_value
-            elif (dynamic_comparison_type == DynamicComparisonType.DECREASED):
+            elif dynamic_comparison_type == DynamicComparisonType.DECREASED:
                 if value <= current_value:
                     self._memory_cache.pop(addr)
                 else:
                     self._memory_cache[addr] = current_value
-            elif (dynamic_comparison_type == DynamicComparisonType.MATCH):
+            elif dynamic_comparison_type == DynamicComparisonType.MATCH:
                 if new_value == None:
                     raise ValueError("new_value must be specified when using DynamicComparisonType.MATCH")
                 if current_value != new_value:

--- a/pyboy/api/screen.py
+++ b/pyboy/api/screen.py
@@ -29,6 +29,7 @@ class Screen:
     If you're making an AI or bot, it's highly recommended to _not_ use this class for detecting objects on the screen.
     It's much more efficient to use `pyboy.PyBoy.tilemap_background`, `pyboy.PyBoy.tilemap_window`, and `pyboy.PyBoy.get_sprite` instead.
     """
+
     def __init__(self, mb):
         self.mb = mb
 
@@ -119,7 +120,7 @@ class Screen:
             RGB image of (160, 144) pixels
         """
         if not Image:
-            logger.warning("Cannot generate screen image. Missing dependency \"Pillow\".")
+            logger.warning('Cannot generate screen image. Missing dependency "Pillow".')
         else:
             self._set_image()
 
@@ -164,8 +165,9 @@ class Screen:
 
     def _set_image(self):
         self.image = Image.frombuffer(
-            self.mb.lcd.renderer.color_format, self.mb.lcd.renderer.buffer_dims[::-1],
-            self.mb.lcd.renderer._screenbuffer_raw
+            self.mb.lcd.renderer.color_format,
+            self.mb.lcd.renderer.buffer_dims[::-1],
+            self.mb.lcd.renderer._screenbuffer_raw,
         )
 
     @property

--- a/pyboy/api/sprite.py
+++ b/pyboy/api/sprite.py
@@ -175,7 +175,7 @@ class Sprite:
         if sprite_height == 16:
             self.tiles += [Tile(self.mb, self.tile_identifier + 1)]
 
-        self.on_screen = (-sprite_height < self.y < 144 and -8 < self.x < 160)
+        self.on_screen = -sprite_height < self.y < 144 and -8 < self.x < 160
         """
         To disable sprites from being rendered on screen, developers will place the sprite outside the area of the
         screen. This is often a good way to determine if the sprite is inactive.

--- a/pyboy/api/tile.py
+++ b/pyboy/api/tile.py
@@ -23,6 +23,7 @@ except ImportError:
 
 try:
     from cython import compiled
+
     cythonmode = compiled
 except ImportError:
     cythonmode = False
@@ -48,7 +49,7 @@ class Tile:
         else:
             assert 0 <= identifier < TILES, "Identifier out of range"
 
-        self.data_address = LOW_TILEDATA + (16 * (identifier%TILES))
+        self.data_address = LOW_TILEDATA + (16 * (identifier % TILES))
         """
         The tile data is defined in a specific area of the Game Boy. This function returns the address of the tile data
         corresponding to the tile identifier. It is advised to use `pyboy.api.tile.Tile.image` or one of the
@@ -119,7 +120,7 @@ class Tile:
             Image of tile in 8x8 pixels and RGBA colors.
         """
         if Image is None:
-            logger.error(f"{__name__}: Missing dependency \"Pillow\".")
+            logger.error(f'{__name__}: Missing dependency "Pillow".')
             return None
 
         if cythonmode:
@@ -182,7 +183,7 @@ class Tile:
             Image data of tile in 8x8 pixels and RGB colors.
         """
         self.data = np.zeros((8, 8), dtype=np.uint32)
-        for k in range(0, 16, 2): # 2 bytes for each line
+        for k in range(0, 16, 2):  # 2 bytes for each line
             if self.vram_bank == 0:
                 byte1 = self.mb.lcd.VRAM0[self.data_address + k - VRAM_OFFSET]
                 byte2 = self.mb.lcd.VRAM0[self.data_address + k + 1 - VRAM_OFFSET]

--- a/pyboy/api/tilemap.py
+++ b/pyboy/api/tilemap.py
@@ -189,7 +189,7 @@ class TileMap:
         adjust = 4
         _use_tile_objects = self._use_tile_objects
         self.use_tile_objects(False)
-        # yapf: disable
+
         return_data = (
             f"Tile Map Address: {self.map_offset:#0{6}x}, " +
             f"Signed Tile Data: {'Yes' if self.signed_tile_data else 'No'}\n" +
@@ -202,7 +202,6 @@ class TileMap:
                 ]
             )
         )
-        # yapf: enable
         self.use_tile_objects(_use_tile_objects)
         return return_data
 

--- a/pyboy/api/tilemap.py
+++ b/pyboy/api/tilemap.py
@@ -137,7 +137,7 @@ class TileMap:
             raise IndexError("column is out of bounds. Value of 0 to 31 is allowed")
         if not 0 <= row < 32:
             raise IndexError("row is out of bounds. Value of 0 to 31 is allowed")
-        return self.map_offset + 32*row + column
+        return self.map_offset + 32 * row + column
 
     def tile(self, column, row):
         """
@@ -191,11 +191,14 @@ class TileMap:
         self.use_tile_objects(False)
 
         return_data = (
-            f"Tile Map Address: {self.map_offset:#0{6}x}, " +
-            f"Signed Tile Data: {'Yes' if self.signed_tile_data else 'No'}\n" +
-            " "*5 + "".join([f"{i: <4}" for i in range(32)]) + "\n" +
-            "_"*(adjust*32+2) + "\n" +
-            "\n".join(
+            f"Tile Map Address: {self.map_offset:#0{6}x}, "
+            + f"Signed Tile Data: {'Yes' if self.signed_tile_data else 'No'}\n"
+            + " " * 5
+            + "".join([f"{i: <4}" for i in range(32)])
+            + "\n"
+            + "_" * (adjust * 32 + 2)
+            + "\n"
+            + "\n".join(
                 [
                     f"{i: <3}| " + "".join([str(tile).ljust(adjust) for tile in line])
                     for i, line in enumerate(self[:, :])

--- a/pyboy/conftest.py
+++ b/pyboy/conftest.py
@@ -50,7 +50,7 @@ def locate_roms(path=default_rom_path):
         lambda x: path + x,
         filter(
             lambda x: x.lower().endswith(".gb") or x.lower().endswith(".gbc") or x.endswith(".bin"), os.listdir(path)
-        )
+        ),
     )
 
     entries = {}
@@ -112,27 +112,29 @@ def pokemon_pinball_rom(secrets):
     return locate_sha256(b"7672001d4710272009df6a41e3cbada65decd56e0eb2f185cb3d59c08d33ea0e")
 
 
-tetris_game_area = np.array([
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 130, 130, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 130, 130, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-],
-                            dtype=np.uint32)
+tetris_game_area = np.array(
+    [
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 130, 130, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 130, 130, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+        [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+    ],
+    dtype=np.uint32,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -200,6 +202,7 @@ class PytestDoctestRunner(doctest.DebugRunner):
     Note that the out variable in this case is a list instead of a
     stdout-like object.
     """
+
     def __init__(
         self,
         checker=None,
@@ -275,15 +278,15 @@ class DoctestTextfile(pytest.Module):
         grouped_examples = [[]]
         for (lineno, example), i in zip([(e.lineno, e) for e in examples], range(len(examples))):
             # Fix parsing error when example ends
-            example.want = example.want.split("```\n")[0] # Stop parsing, if the docstring ends
+            example.want = example.want.split("```\n")[0]  # Stop parsing, if the docstring ends
 
             if lineno - i == last:
                 grouped_examples[-1].append(example)
             else:
                 grouped_examples.append([example])
                 last = lineno - i
-            last += example.source.count("\n") - 1 # Handle multi-line definitions
-            last += example.want.count("\n") # Handle multi-line definitions
+            last += example.source.count("\n") - 1  # Handle multi-line definitions
+            last += example.want.count("\n")  # Handle multi-line definitions
 
         # TODO: Better naming
         for test in [

--- a/pyboy/conftest.py
+++ b/pyboy/conftest.py
@@ -147,6 +147,7 @@ def doctest_fixtures(doctest_namespace, default_rom, default_rom_cgb, supermario
         return PyBoy(filename, *args, window="null", **kwargs)
 
     # We mock get_sprite_by_tile_identifier as default_rom doesn't use sprites
+    # fmt: off
     with mock.patch("pyboy.PyBoy.get_sprite_by_tile_identifier", return_value=[[0, 2, 4], []]), \
         mock.patch("pyboy.PyBoy.game_area_collision", return_value=np.zeros(shape=(10,9), dtype=np.uint32)), \
         mock.patch("pyboy.PyBoy.game_area", return_value=tetris_game_area), \
@@ -154,6 +155,7 @@ def doctest_fixtures(doctest_namespace, default_rom, default_rom_cgb, supermario
         mock.patch("pyboy.PyBoy.stop", return_value=None), \
         mock.patch("pyboy.PyBoy.rtc_lock_experimental", return_value=None), \
         mock.patch("PIL.Image.Image.show", return_value=None):
+        # fmt: on
 
         pyboy.set_emulation_speed(0)
         pyboy.tick(10) # Just a few to get the logo up

--- a/pyboy/core/cartridge/base_mbc.py
+++ b/pyboy/core/cartridge/base_mbc.py
@@ -100,7 +100,7 @@ class BaseMBC:
         self.rambank_initialized = True
         # In real life the values in RAM are scrambled on initialization.
         # Allocating the maximum, as it is easier in Cython. And it's just 128KB...
-        self.rambanks = memoryview(array.array("B", [0] * (8*1024*16))).cast("B", shape=(16, 8 * 1024))
+        self.rambanks = memoryview(array.array("B", [0] * (8 * 1024 * 16))).cast("B", shape=(16, 8 * 1024))
 
     def getgamename(self, rombanks):
         return "".join([chr(rombanks[0, x]) for x in range(0x0134, 0x0142)]).split("\0")[0]
@@ -111,8 +111,11 @@ class BaseMBC:
     def overrideitem(self, rom_bank, address, value):
         if 0x0000 <= address < 0x4000:
             logger.debug(
-                "Performing overwrite on address: 0x%04x:0x%04x. New value: 0x%04x Old value: 0x%04x", rom_bank,
-                address, value, self.rombanks[rom_bank, address]
+                "Performing overwrite on address: 0x%04x:0x%04x. New value: 0x%04x Old value: 0x%04x",
+                rom_bank,
+                address,
+                value,
+                self.rombanks[rom_bank, address],
             )
             self.rombanks[rom_bank, address] = value
         else:
@@ -134,20 +137,22 @@ class BaseMBC:
         #     logger.error("Reading address invalid: %0.4x", address)
 
     def __repr__(self):
-        return "\n".join([
-            "MBC class: %s" % self.__class__.__name__,
-            "Filename: %s" % self.filename,
-            "Game name: %s" % self.gamename,
-            "GB Color: %s" % str(self.rombanks[0, 0x143] == 0x80),
-            "Cartridge type: %s" % hex(self.carttype),
-            "Number of ROM banks: %s" % self.external_rom_count,
-            "Active ROM bank: %s" % self.rombank_selected,
-            # "Memory bank type: %s" % self.ROMBankController,
-            "Number of RAM banks: %s" % len(self.rambanks),
-            "Active RAM bank: %s" % self.rambank_selected,
-            "Battery: %s" % self.battery,
-            "RTC: %s" % self.rtc_enabled
-        ])
+        return "\n".join(
+            [
+                "MBC class: %s" % self.__class__.__name__,
+                "Filename: %s" % self.filename,
+                "Game name: %s" % self.gamename,
+                "GB Color: %s" % str(self.rombanks[0, 0x143] == 0x80),
+                "Cartridge type: %s" % hex(self.carttype),
+                "Number of ROM banks: %s" % self.external_rom_count,
+                "Active ROM bank: %s" % self.rombank_selected,
+                # "Memory bank type: %s" % self.ROMBankController,
+                "Number of RAM banks: %s" % len(self.rambanks),
+                "Active RAM bank: %s" % self.rambank_selected,
+                "Battery: %s" % self.battery,
+                "RTC: %s" % self.rtc_enabled,
+            ]
+        )
 
 
 class ROMOnly(BaseMBC):
@@ -155,7 +160,7 @@ class ROMOnly(BaseMBC):
         if 0x2000 <= address < 0x4000:
             if value == 0:
                 value = 1
-            self.rombank_selected = (value & 0b1)
+            self.rombank_selected = value & 0b1
             logger.debug("Switching bank 0x%0.4x, 0x%0.2x", address, value)
         elif 0xA000 <= address < 0xC000:
             self.rambanks[self.rambank_selected, address - 0xA000] = value

--- a/pyboy/core/cartridge/cartridge.py
+++ b/pyboy/core/cartridge/cartridge.py
@@ -64,7 +64,7 @@ def load_romfile(filename):
     return memoryview(romdata).cast("B", shape=(len(romdata) // banksize, banksize))
 
 
-# yapf: disable
+# fmt: off
 CARTRIDGE_TABLE = {
     #      MBC     , SRAM  , Battery , RTC
     0x00: (ROMOnly , False , False   , False) , # ROM
@@ -87,7 +87,7 @@ CARTRIDGE_TABLE = {
     0x1D: (MBC5    , True  , False   , False) , # MBC5+RUMBLE+RAM
     0x1E: (MBC5    , True  , True    , False) , # MBC5+RUMBLE+RAM+BATT
 }
-# yapf: enable
+# fmt: on
 
 # Number of external 8KB banks in the cartridge. Taken from Pan Docs
 EXTERNAL_RAM_TABLE = {

--- a/pyboy/core/cartridge/cartridge.py
+++ b/pyboy/core/cartridge/cartridge.py
@@ -43,7 +43,7 @@ def validate_checksum(rombanks):
     x = 0
     for m in range(0x134, 0x14D):
         x = x - rombanks[0, m] - 1
-        x &= 0xff
+        x &= 0xFF
     return rombanks[0, 0x14D] == x
 
 
@@ -91,8 +91,8 @@ CARTRIDGE_TABLE = {
 
 # Number of external 8KB banks in the cartridge. Taken from Pan Docs
 EXTERNAL_RAM_TABLE = {
-    0x00: 1, # We wrongfully allocate some RAM, to help Cython
-    0x01: 1, # Only supposed to be 2KB, but we allocate 8KB.
+    0x00: 1,  # We wrongfully allocate some RAM, to help Cython
+    0x01: 1,  # Only supposed to be 2KB, but we allocate 8KB.
     0x02: 1,
     0x03: 4,
     0x04: 16,

--- a/pyboy/core/cartridge/mbc1.py
+++ b/pyboy/core/cartridge/mbc1.py
@@ -41,8 +41,9 @@ class MBC1(BaseMBC):
             self.rombank_selected_low = (self.bank_select_register2 << 5) % self.external_rom_count
         else:
             self.rombank_selected_low = 0
-        self.rombank_selected = ((self.bank_select_register2 << 5) |
-                                 self.bank_select_register1) % self.external_rom_count
+        self.rombank_selected = (
+            (self.bank_select_register2 << 5) | self.bank_select_register1
+        ) % self.external_rom_count
 
     def getitem(self, address):
         if 0xA000 <= address < 0xC000:

--- a/pyboy/core/cartridge/mbc2.py
+++ b/pyboy/core/cartridge/mbc2.py
@@ -15,8 +15,8 @@ class MBC2(BaseMBC):
     def setitem(self, address, value):
         if 0x0000 <= address < 0x4000:
             value &= 0b00001111
-            if ((address & 0x100) == 0):
-                self.rambank_enabled = (value == 0b00001010)
+            if (address & 0x100) == 0:
+                self.rambank_enabled = value == 0b00001010
             else:
                 if value == 0:
                     value = 1

--- a/pyboy/core/cartridge/mbc5.py
+++ b/pyboy/core/cartridge/mbc5.py
@@ -15,7 +15,7 @@ class MBC5(BaseMBC):
     def setitem(self, address, value):
         if 0x0000 <= address < 0x2000:
             # 8-bit register. All bits matter, so only 0b00001010 enables RAM.
-            self.rambank_enabled = (value == 0b00001010)
+            self.rambank_enabled = value == 0b00001010
         elif 0x2000 <= address < 0x3000:
             # 8-bit register used for the lower 8 bits of the ROM bank number.
             self.rombank_selected = ((self.rombank_selected & 0b100000000) | value) % self.external_rom_count

--- a/pyboy/core/cartridge/rtc.py
+++ b/pyboy/core/cartridge/rtc.py
@@ -56,8 +56,8 @@ class RTC:
         else:
             t = time.time() - self.timezero
         self.sec_latch = int(t % 60)
-        self.min_latch = int((t//60) % 60)
-        self.hour_latch = int((t//3600) % 24)
+        self.min_latch = int((t // 60) % 60)
+        self.hour_latch = int((t // 3600) % 24)
         days = int(t // 3600 // 24)
         self.day_latch_low = days & 0xFF
         self.day_latch_high = days >> 8
@@ -108,13 +108,13 @@ class RTC:
             t = time.time() - self.timezero
         if register == 0x08:
             # TODO: What happens, when these value are larger than allowed?
-            self.timezero = self.timezero - (t%60) - value
+            self.timezero = self.timezero - (t % 60) - value
         elif register == 0x09:
-            self.timezero = self.timezero - (t//60%60) - value
+            self.timezero = self.timezero - (t // 60 % 60) - value
         elif register == 0x0A:
-            self.timezero = self.timezero - (t//3600%24) - value
+            self.timezero = self.timezero - (t // 3600 % 24) - value
         elif register == 0x0B:
-            self.timezero = self.timezero - (t//3600//24) - value
+            self.timezero = self.timezero - (t // 3600 // 24) - value
         elif register == 0x0C:
             day_high = value & 0b1
             halt = (value & 0b1000000) >> 6
@@ -122,11 +122,11 @@ class RTC:
 
             self.halt = halt
             if self.halt == 0:
-                pass # TODO: Start the timer
+                pass  # TODO: Start the timer
             else:
                 logger.warning("Stopping RTC is not implemented!")
 
-            self.timezero = self.timezero - (t//3600//24) - (day_high << 8)
+            self.timezero = self.timezero - (t // 3600 // 24) - (day_high << 8)
             self.day_carry = day_carry
         else:
             logger.warning("Invalid RTC register: %0.4x %0.2x", register, value)

--- a/pyboy/core/cpu.py
+++ b/pyboy/core/cpu.py
@@ -78,7 +78,7 @@ class CPU:
     def dump_state(self, sym_label):
         opcode_data = [
             self.mb.getitem(self.mb.cpu.PC + n) for n in range(3)
-        ] # Max 3 length, then we don't need to backtrack
+        ]  # Max 3 length, then we don't need to backtrack
 
         opcode = opcode_data[0]
         opcode_length = opcodes.OPCODE_LENGTHS[opcode]
@@ -123,14 +123,14 @@ class CPU:
             self.PC += 1
             self.PC &= 0xFFFF
         elif self.halted:
-            self.cycles += cycles_target # TODO: Number of cycles for a HALT in effect?
+            self.cycles += cycles_target  # TODO: Number of cycles for a HALT in effect?
         self.interrupt_queued = False
 
         self.bail = False
         while self.cycles < _target:
             # TODO: cpu-stuck check for blargg tests?
             self.fetch_and_execute()
-            if self.bail: # Possible cycles-target changes
+            if self.bail:  # Possible cycles-target changes
                 break
 
     def check_interrupts(self):
@@ -142,7 +142,7 @@ class CPU:
         if raised_and_enabled:
             # Clear interrupt flag
             if self.halted:
-                self.PC += 1 # Escape HALT on return
+                self.PC += 1  # Escape HALT on return
                 self.PC &= 0xFFFF
 
             if self.interrupt_master_enable:
@@ -163,9 +163,9 @@ class CPU:
         return False
 
     def handle_interrupt(self, flag, addr):
-        self.interrupts_flag_register ^= flag # Remove flag
-        self.mb.setitem((self.SP - 1) & 0xFFFF, self.PC >> 8) # High
-        self.mb.setitem((self.SP - 2) & 0xFFFF, self.PC & 0xFF) # Low
+        self.interrupts_flag_register ^= flag  # Remove flag
+        self.mb.setitem((self.SP - 1) & 0xFFFF, self.PC >> 8)  # High
+        self.mb.setitem((self.SP - 2) & 0xFFFF, self.PC & 0xFF)  # Low
         self.SP -= 2
         self.SP &= 0xFFFF
 
@@ -174,8 +174,8 @@ class CPU:
 
     def fetch_and_execute(self):
         opcode = self.mb.getitem(self.PC)
-        if opcode == 0xCB: # Extension code
+        if opcode == 0xCB:  # Extension code
             opcode = self.mb.getitem(self.PC + 1)
-            opcode += 0x100 # Internally shifting look-up table
+            opcode += 0x100  # Internally shifting look-up table
 
         return opcodes.execute_opcode(self, opcode)

--- a/pyboy/core/interaction.py
+++ b/pyboy/core/interaction.py
@@ -62,8 +62,7 @@ class Interaction:
 
         # XOR to find the changed bits, AND it to see if it was high before.
         # Test for both directional and standard buttons.
-        return ((_directional ^ self.directional) & _directional) or \
-               ((_standard ^ self.standard) & _standard)
+        return ((_directional ^ self.directional) & _directional) or ((_standard ^ self.standard) & _standard)
 
     def pull(self, joystickbyte):
         P14 = (joystickbyte >> 4) & 1

--- a/pyboy/core/lcd.py
+++ b/pyboy/core/lcd.py
@@ -392,7 +392,7 @@ class LCDCRegister:
         self.value = value
 
         # No need to convert to bool. Any non-zero value is true.
-        # yapf: disable
+        # fmt: off
         self.lcd_enable           = value & (1 << 7)
         self.windowmap_select     = value & (1 << 6)
         self.window_enable        = value & (1 << 5)
@@ -402,7 +402,7 @@ class LCDCRegister:
         self.sprite_enable        = value & (1 << 1)
         self.background_enable    = value & (1 << 0)
         self.cgb_master_priority  = self.background_enable # Different meaning on CGB
-        # yapf: enable
+        # fmt: on
 
         # All VRAM addresses are offset by 0x8000
         # Following addresses are 0x9800 and 0x9C00

--- a/pyboy/core/opcodes_gen.py
+++ b/pyboy/core/opcodes_gen.py
@@ -83,7 +83,7 @@ class MyHTMLParser(HTMLParser):
     def handle_endtag(self, tag):
         if not self.founddata and self.tagstack[-1] == "td" and self.counter % 0x100 != 0:
             self.counter += 1
-            opcodes.append(None) # Blank operations
+            opcodes.append(None)  # Blank operations
         self.tagstack.pop()
 
     def handle_data(self, data):
@@ -158,9 +158,11 @@ class Operand:
         elif operand.startswith("(") and operand.endswith(")"):
             self.pointer = True
             if assign:
-                code = "cpu.mb.setitem(%s" % self.codegen(
-                    False, operand=re.search(r"\(([a-zA-Z]+\d*)[\+-]?\)", operand).group(1)
-                ) + ", %s)"
+                code = (
+                    "cpu.mb.setitem(%s"
+                    % self.codegen(False, operand=re.search(r"\(([a-zA-Z]+\d*)[\+-]?\)", operand).group(1))
+                    + ", %s)"
+                )
             else:
                 code = "cpu.mb.getitem(%s)" % self.codegen(
                     False, operand=re.search(r"\(([a-zA-Z]+\d*)[\+-]?\)", operand).group(1)
@@ -198,7 +200,7 @@ class Operand:
             else:
                 return "((cpu." + operand[0] + " << 8) + cpu." + operand[1] + ")"
 
-        elif operand in ["Z", "C", "NZ", "NC"]: # flags
+        elif operand in ["Z", "C", "NZ", "NC"]:  # flags
             assert not assign
             self.flag = True
 
@@ -261,24 +263,24 @@ class Code:
         code = ""
         code += [
             "def %s_%0.2X(cpu): # %0.2X %s" % (self.function_name, self.opcode, self.opcode, self.name),
-            "def %s_%0.2X(cpu, v): # %0.2X %s" % (self.function_name, self.opcode, self.opcode, self.name)
+            "def %s_%0.2X(cpu, v): # %0.2X %s" % (self.function_name, self.opcode, self.opcode, self.name),
         ][self.takes_immediate]
         code += "\n\t"
 
         if not self.branch_op:
             self.lines.append("cpu.PC += %d" % self.length)
             self.lines.append("cpu.PC &= 0xFFFF")
-            self.lines.append("cpu.cycles += " + self.cycles[0]) # Choose the 0th cycle count
+            self.lines.append("cpu.cycles += " + self.cycles[0])  # Choose the 0th cycle count
 
         code += "\n\t".join(self.lines)
 
         pxd = [
-            "cdef uint8_t %s_%0.2X(cpu.CPU) noexcept nogil # %0.2X %s" %
-            (self.function_name, self.opcode, self.opcode, self.name),
+            "cdef uint8_t %s_%0.2X(cpu.CPU) noexcept nogil # %0.2X %s"
+            % (self.function_name, self.opcode, self.opcode, self.name),
             # TODO: Differentiate between 16-bit values
             # (01,11,21,31 ops) and 8-bit values for 'v'
-            "cdef uint8_t %s_%0.2X(cpu.CPU, int v) noexcept nogil # %0.2X %s" %
-            (self.function_name, self.opcode, self.opcode, self.name),
+            "cdef uint8_t %s_%0.2X(cpu.CPU, int v) noexcept nogil # %0.2X %s"
+            % (self.function_name, self.opcode, self.opcode, self.name),
         ][self.takes_immediate]
 
         if self.opcode == 0x27:
@@ -304,51 +306,51 @@ class OpcodeData:
 
         # TODO: There's no need for this to be so explicit
         self.functionhandlers = {
-            "NOP"    : self.NOP,
-            "HALT"   : self.HALT,
-            "PREFIX" : self.CB,
-            "EI"     : self.EI,
-            "DI"     : self.DI,
-            "STOP"   : self.STOP,
-            "LD"     : self.LD,
-            "LDH"    : self.LDH,
-            "ADD"    : self.ADD,
-            "SUB"    : self.SUB,
-            "INC"    : self.INC,
-            "DEC"    : self.DEC,
-            "ADC"    : self.ADC,
-            "SBC"    : self.SBC,
-            "AND"    : self.AND,
-            "OR"     : self.OR,
-            "XOR"    : self.XOR,
-            "CP"     : self.CP,
-            "PUSH"   : self.PUSH,
-            "POP"    : self.POP,
-            "JP"     : self.JP,
-            "JR"     : self.JR,
-            "CALL"   : self.CALL,
-            "RET"    : self.RET,
-            "RETI"   : self.RETI,
-            "RST"    : self.RST,
-            "DAA"    : self.DAA,
-            "SCF"    : self.SCF,
-            "CCF"    : self.CCF,
-            "CPL"    : self.CPL,
-            "RLA"    : self.RLA,
-            "RLCA"   : self.RLCA,
-            "RLC"    : self.RLC,
-            "RL"     : self.RL,
-            "RRA"    : self.RRA,
-            "RRCA"   : self.RRCA,
-            "RRC"    : self.RRC,
-            "RR"     : self.RR,
-            "SLA"    : self.SLA,
-            "SRA"    : self.SRA,
-            "SWAP"   : self.SWAP,
-            "SRL"    : self.SRL,
-            "BIT"    : self.BIT,
-            "RES"    : self.RES,
-            "SET"    : self.SET,
+            "NOP": self.NOP,
+            "HALT": self.HALT,
+            "PREFIX": self.CB,
+            "EI": self.EI,
+            "DI": self.DI,
+            "STOP": self.STOP,
+            "LD": self.LD,
+            "LDH": self.LDH,
+            "ADD": self.ADD,
+            "SUB": self.SUB,
+            "INC": self.INC,
+            "DEC": self.DEC,
+            "ADC": self.ADC,
+            "SBC": self.SBC,
+            "AND": self.AND,
+            "OR": self.OR,
+            "XOR": self.XOR,
+            "CP": self.CP,
+            "PUSH": self.PUSH,
+            "POP": self.POP,
+            "JP": self.JP,
+            "JR": self.JR,
+            "CALL": self.CALL,
+            "RET": self.RET,
+            "RETI": self.RETI,
+            "RST": self.RST,
+            "DAA": self.DAA,
+            "SCF": self.SCF,
+            "CCF": self.CCF,
+            "CPL": self.CPL,
+            "RLA": self.RLA,
+            "RLCA": self.RLCA,
+            "RLC": self.RLC,
+            "RL": self.RL,
+            "RRA": self.RRA,
+            "RRCA": self.RRCA,
+            "RRC": self.RRC,
+            "RR": self.RR,
+            "SLA": self.SLA,
+            "SRA": self.SRA,
+            "SWAP": self.SWAP,
+            "SRL": self.SRL,
+            "BIT": self.BIT,
+            "RES": self.RES,
+            "SET": self.SET,
         }
 
     def createfunction(self):
@@ -459,11 +461,13 @@ class OpcodeData:
         code = Code(self.name.split()[0], self.opcode, self.name, 0, self.length, self.cycles, branch_op=True)
 
         # TODO: Implement HALT bug.
-        code.addlines([
-            "cpu.halted = True",
-            "cpu.bail = True",
-            "cpu.cycles += " + self.cycles[0],
-        ])
+        code.addlines(
+            [
+                "cpu.halted = True",
+                "cpu.bail = True",
+                "cpu.cycles += " + self.cycles[0],
+            ]
+        )
         return code.getcode()
 
     def CB(self):
@@ -473,10 +477,12 @@ class OpcodeData:
 
     def EI(self):
         code = Code(self.name.split()[0], self.opcode, self.name, 0, self.length, self.cycles)
-        code.addlines([
-            "cpu.interrupt_master_enable = True",
-            "cpu.bail = (cpu.interrupts_flag_register & 0b11111) & (cpu.interrupts_enabled_register & 0b11111)",
-        ])
+        code.addlines(
+            [
+                "cpu.interrupt_master_enable = True",
+                "cpu.bail = (cpu.interrupts_flag_register & 0b11111) & (cpu.interrupts_enabled_register & 0b11111)",
+            ]
+        )
         return code.getcode()
 
     def DI(self):
@@ -486,11 +492,13 @@ class OpcodeData:
 
     def STOP(self):
         code = Code(self.name.split()[0], self.opcode, self.name, True, self.length, self.cycles)
-        code.addlines([
-            "if cpu.mb.cgb:",
-            "    cpu.mb.switch_speed()",
-            "    cpu.mb.setitem(0xFF04, 0)",
-        ])
+        code.addlines(
+            [
+                "if cpu.mb.cgb:",
+                "    cpu.mb.switch_speed()",
+                "    cpu.mb.setitem(0xFF04, 0)",
+            ]
+        )
         # code.addLine("raise Exception('STOP not implemented!')")
         return code.getcode()
 
@@ -500,25 +508,27 @@ class OpcodeData:
 
         # http://stackoverflow.com/a/29990058/3831206
         # http://forums.nesdev.com/viewtopic.php?t=9088
-        code.addlines([
-            "t = %s" % left.get,
-            "corr = 0",
-            "corr |= 0x06 if ((cpu.F & (1 << FLAGH)) != 0) else 0x00",
-            "corr |= 0x60 if ((cpu.F & (1 << FLAGC)) != 0) else 0x00",
-            "if (cpu.F & (1 << FLAGN)) != 0:",
-            "\tt -= corr",
-            "else:",
-            "\tcorr |= 0x06 if (t & 0x0F) > 0x09 else 0x00",
-            "\tcorr |= 0x60 if t > 0x99 else 0x00",
-            "\tt += corr",
-            "flag = 0",
-            "flag += ((t & 0xFF) == 0) << FLAGZ",
-            "flag += (corr & 0x60 != 0) << FLAGC",
-            "cpu.F &= 0b01000000",
-            "cpu.F |= flag",
-            "t &= 0xFF",
-            left.set % "t",
-        ])
+        code.addlines(
+            [
+                "t = %s" % left.get,
+                "corr = 0",
+                "corr |= 0x06 if ((cpu.F & (1 << FLAGH)) != 0) else 0x00",
+                "corr |= 0x60 if ((cpu.F & (1 << FLAGC)) != 0) else 0x00",
+                "if (cpu.F & (1 << FLAGN)) != 0:",
+                "\tt -= corr",
+                "else:",
+                "\tcorr |= 0x06 if (t & 0x0F) > 0x09 else 0x00",
+                "\tcorr |= 0x60 if t > 0x99 else 0x00",
+                "\tt += corr",
+                "flag = 0",
+                "flag += ((t & 0xFF) == 0) << FLAGZ",
+                "flag += (corr & 0x60 != 0) << FLAGC",
+                "cpu.F &= 0b01000000",
+                "cpu.F |= flag",
+                "t &= 0xFF",
+                left.set % "t",
+            ]
+        )
         return code.getcode()
 
     def SCF(self):
@@ -528,11 +538,13 @@ class OpcodeData:
 
     def CCF(self):
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles)
-        code.addlines([
-            "flag = (cpu.F & 0b00010000) ^ 0b00010000",
-            "cpu.F &= 0b10000000",
-            "cpu.F |= flag",
-        ])
+        code.addlines(
+            [
+                "flag = (cpu.F & 0b00010000) ^ 0b00010000",
+                "cpu.F &= 0b10000000",
+                "cpu.F |= flag",
+            ]
+        )
         return code.getcode()
 
     def CPL(self):
@@ -562,24 +574,24 @@ class OpcodeData:
         # These opcodes can be observed reading mid-cycle
         if self.opcode == 0x36:
             code.addline("cpu.cycles += 4")
-            code.cycles = (str(int(code.cycles[0]) - 4), )
+            code.cycles = (str(int(code.cycles[0]) - 4),)
         elif self.opcode == 0xE0:
             code.addline("cpu.cycles += 4")
-            code.cycles = (str(int(code.cycles[0]) - 4), )
+            code.cycles = (str(int(code.cycles[0]) - 4),)
         elif self.opcode == 0xEA:
             code.addline("cpu.cycles += 8")
-            code.cycles = (str(int(code.cycles[0]) - 8), )
+            code.cycles = (str(int(code.cycles[0]) - 8),)
         elif self.opcode == 0xF0:
             code.addline("cpu.cycles += 4")
-            code.cycles = (str(int(code.cycles[0]) - 4), )
+            code.cycles = (str(int(code.cycles[0]) - 4),)
         elif self.opcode == 0xFA:
             code.addline("cpu.cycles += 8")
-            code.cycles = (str(int(code.cycles[0]) - 8), )
+            code.cycles = (str(int(code.cycles[0]) - 8),)
 
         if self.is16bit and left.immediate and left.pointer:
             code.addline(left.set % ("%s & 0xFF" % right.get))
             a, b = left.set.split(",")
-            code.addline((a+"+1,"+b) % ("%s >> 8" % right.get))
+            code.addline((a + "+1," + b) % ("%s >> 8" % right.get))
         else:
             # Special handling of AF, BC, DE
             # print(left.set, right.get, hex(self.opcode))
@@ -685,8 +697,8 @@ class OpcodeData:
         if self.opcode == 0x34:
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(-1, "cpu.cycles += 4") # Inject before read
-            code.cycles = ("8", ) # 12 - 4
+            code.lines.insert(-1, "cpu.cycles += 4")  # Inject before read
+            code.cycles = ("8",)  # 12 - 4
 
         return code.getcode()
 
@@ -703,8 +715,8 @@ class OpcodeData:
         if self.opcode == 0x35:
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(-1, "cpu.cycles += 4") # Inject before write
-            code.cycles = ("8", ) # 12 - 4
+            code.lines.insert(-1, "cpu.cycles += 4")  # Inject before write
+            code.cycles = ("8",)  # 12 - 4
 
         return code.getcode()
 
@@ -811,12 +823,14 @@ class OpcodeData:
 
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles)
         if "HL" in left.get:
-            code.addlines([
-                "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.HL >> 8) # High",
-                "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.HL & 0xFF) # Low",
-                "cpu.SP -= 2",
-                "cpu.SP &= 0xFFFF",
-            ])
+            code.addlines(
+                [
+                    "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.HL >> 8) # High",
+                    "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.HL & 0xFF) # Low",
+                    "cpu.SP -= 2",
+                    "cpu.SP &= 0xFFFF",
+                ]
+            )
         else:
             # A bit of a hack, but you can only push double registers
             code.addline("cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.%s) # High" % left.operand[-2])
@@ -837,14 +851,15 @@ class OpcodeData:
 
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles)
         if "HL" in left.get:
-            code.addlines([
-                (left.set % "(cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8) + "
-                 "cpu.mb.getitem(cpu.SP)") + " # High",
-                "cpu.SP += 2",
-                "cpu.SP &= 0xFFFF",
-            ])
+            code.addlines(
+                [
+                    (left.set % "(cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8) + " "cpu.mb.getitem(cpu.SP)") + " # High",
+                    "cpu.SP += 2",
+                    "cpu.SP &= 0xFFFF",
+                ]
+            )
         else:
-            if left.operand.endswith("F"): # Catching AF
+            if left.operand.endswith("F"):  # Catching AF
                 fmask = " & 0xF0"
             else:
                 fmask = ""
@@ -893,15 +908,17 @@ class OpcodeData:
         if left is None:
             code.addlines(["cpu.PC = %s" % ("v" if right.immediate else r_code), "cpu.cycles += " + self.cycles[0]])
         else:
-            code.addlines([
-                "if %s:" % l_code,
-                "\tcpu.PC = %s" % ("v" if right.immediate else r_code),
-                "\tcpu.cycles += " + self.cycles[0],
-                "else:",
-                "\tcpu.PC += %s" % self.length,
-                "\tcpu.PC &= 0xFFFF",
-                "\tcpu.cycles += " + self.cycles[1],
-            ])
+            code.addlines(
+                [
+                    "if %s:" % l_code,
+                    "\tcpu.PC = %s" % ("v" if right.immediate else r_code),
+                    "\tcpu.cycles += " + self.cycles[0],
+                    "else:",
+                    "\tcpu.PC += %s" % self.length,
+                    "\tcpu.PC &= 0xFFFF",
+                    "\tcpu.cycles += " + self.cycles[1],
+                ]
+            )
 
         return code.getcode()
 
@@ -927,22 +944,26 @@ class OpcodeData:
             self.name.split()[0], self.opcode, self.name, right.immediate, self.length, self.cycles, branch_op=True
         )
         if left is None:
-            code.addlines([
-                "cpu.PC += %d + " % self.length + inline_signed_int8("v"),
-                "cpu.PC &= 0xFFFF",
-                "cpu.cycles += " + self.cycles[0],
-            ])
+            code.addlines(
+                [
+                    "cpu.PC += %d + " % self.length + inline_signed_int8("v"),
+                    "cpu.PC &= 0xFFFF",
+                    "cpu.cycles += " + self.cycles[0],
+                ]
+            )
         else:
-            code.addlines([
-                "cpu.PC += %d" % self.length,
-                "if %s:" % l_code,
-                "\tcpu.PC += " + inline_signed_int8("v"),
-                "\tcpu.PC &= 0xFFFF",
-                "\tcpu.cycles += " + self.cycles[0],
-                "else:",
-                "\tcpu.PC &= 0xFFFF",
-                "\tcpu.cycles += " + self.cycles[1],
-            ])
+            code.addlines(
+                [
+                    "cpu.PC += %d" % self.length,
+                    "if %s:" % l_code,
+                    "\tcpu.PC += " + inline_signed_int8("v"),
+                    "\tcpu.PC &= 0xFFFF",
+                    "\tcpu.cycles += " + self.cycles[0],
+                    "else:",
+                    "\tcpu.PC &= 0xFFFF",
+                    "\tcpu.cycles += " + self.cycles[1],
+                ]
+            )
 
         return code.getcode()
 
@@ -969,32 +990,38 @@ class OpcodeData:
         )
 
         # Taken from PUSH
-        code.addlines([
-            "cpu.PC += %s" % self.length,
-            "cpu.PC &= 0xFFFF",
-        ])
+        code.addlines(
+            [
+                "cpu.PC += %s" % self.length,
+                "cpu.PC &= 0xFFFF",
+            ]
+        )
 
         if left is None:
-            code.addlines([
-                "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
-                "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
-                "cpu.SP -= 2",
-                "cpu.SP &= 0xFFFF",
-                "cpu.PC = %s" % ("v" if right.immediate else right.get),
-                "cpu.cycles += " + self.cycles[0],
-            ])
+            code.addlines(
+                [
+                    "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
+                    "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
+                    "cpu.SP -= 2",
+                    "cpu.SP &= 0xFFFF",
+                    "cpu.PC = %s" % ("v" if right.immediate else right.get),
+                    "cpu.cycles += " + self.cycles[0],
+                ]
+            )
         else:
-            code.addlines([
-                "if %s:" % l_code,
-                "\tcpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
-                "\tcpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
-                "\tcpu.SP -= 2",
-                "\tcpu.SP &= 0xFFFF",
-                "\tcpu.PC = %s" % ("v" if right.immediate else right.get),
-                "\tcpu.cycles += " + self.cycles[0],
-                "else:",
-                "\tcpu.cycles += " + self.cycles[1],
-            ])
+            code.addlines(
+                [
+                    "if %s:" % l_code,
+                    "\tcpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
+                    "\tcpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
+                    "\tcpu.SP -= 2",
+                    "\tcpu.SP &= 0xFFFF",
+                    "\tcpu.PC = %s" % ("v" if right.immediate else right.get),
+                    "\tcpu.cycles += " + self.cycles[0],
+                    "else:",
+                    "\tcpu.cycles += " + self.cycles[1],
+                ]
+            )
 
         return code.getcode()
 
@@ -1014,40 +1041,46 @@ class OpcodeData:
 
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles, branch_op=True)
         if left is None:
-            code.addlines([
-                "cpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
-                "cpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
-                "cpu.SP += 2",
-                "cpu.SP &= 0xFFFF",
-                "cpu.cycles += " + self.cycles[0],
-            ])
+            code.addlines(
+                [
+                    "cpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
+                    "cpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
+                    "cpu.SP += 2",
+                    "cpu.SP &= 0xFFFF",
+                    "cpu.cycles += " + self.cycles[0],
+                ]
+            )
         else:
-            code.addlines([
-                "if %s:" % l_code,
-                "\tcpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
-                "\tcpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
-                "\tcpu.SP += 2",
-                "\tcpu.SP &= 0xFFFF",
-                "\tcpu.cycles += " + self.cycles[0],
-                "else:",
-                "\tcpu.PC += %s" % self.length,
-                "\tcpu.PC &= 0xFFFF",
-                "\tcpu.cycles += " + self.cycles[1],
-            ])
+            code.addlines(
+                [
+                    "if %s:" % l_code,
+                    "\tcpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
+                    "\tcpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
+                    "\tcpu.SP += 2",
+                    "\tcpu.SP &= 0xFFFF",
+                    "\tcpu.cycles += " + self.cycles[0],
+                    "else:",
+                    "\tcpu.PC += %s" % self.length,
+                    "\tcpu.PC &= 0xFFFF",
+                    "\tcpu.cycles += " + self.cycles[1],
+                ]
+            )
 
         return code.getcode()
 
     def RETI(self):
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles, branch_op=True)
-        code.addlines([
-            "cpu.interrupt_master_enable = True",
-            "cpu.bail = (cpu.interrupts_flag_register & 0b11111) & (cpu.interrupts_enabled_register & 0b11111)",
-            "cpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
-            "cpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
-            "cpu.SP += 2",
-            "cpu.SP &= 0xFFFF",
-            "cpu.cycles += " + self.cycles[0],
-        ])
+        code.addlines(
+            [
+                "cpu.interrupt_master_enable = True",
+                "cpu.bail = (cpu.interrupts_flag_register & 0b11111) & (cpu.interrupts_enabled_register & 0b11111)",
+                "cpu.PC = cpu.mb.getitem((cpu.SP + 1) & 0xFFFF) << 8 # High",
+                "cpu.PC |= cpu.mb.getitem(cpu.SP) # Low",
+                "cpu.SP += 2",
+                "cpu.SP &= 0xFFFF",
+                "cpu.cycles += " + self.cycles[0],
+            ]
+        )
 
         return code.getcode()
 
@@ -1058,19 +1091,23 @@ class OpcodeData:
         code = Code(self.name.split()[0], self.opcode, self.name, False, self.length, self.cycles, branch_op=True)
 
         # Taken from PUSH and CALL
-        code.addlines([
-            "cpu.PC += %s" % self.length,
-            "cpu.PC &= 0xFFFF",
-            "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
-            "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
-            "cpu.SP -= 2",
-            "cpu.SP &= 0xFFFF",
-        ])
+        code.addlines(
+            [
+                "cpu.PC += %s" % self.length,
+                "cpu.PC &= 0xFFFF",
+                "cpu.mb.setitem((cpu.SP-1) & 0xFFFF, cpu.PC >> 8) # High",
+                "cpu.mb.setitem((cpu.SP-2) & 0xFFFF, cpu.PC & 0xFF) # Low",
+                "cpu.SP -= 2",
+                "cpu.SP &= 0xFFFF",
+            ]
+        )
 
-        code.addlines([
-            "cpu.PC = %s" % (right.code),
-            "cpu.cycles += " + self.cycles[0],
-        ])
+        code.addlines(
+            [
+                "cpu.PC = %s" % (right.code),
+                "cpu.cycles += " + self.cycles[0],
+            ]
+        )
 
         return code.getcode()
 
@@ -1092,9 +1129,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code
@@ -1126,8 +1163,11 @@ class OpcodeData:
         left.assign = False
         if throughcarry:
             # Trigger "overflow" for carry flag
-            code.addline(("t = (%s >> 1)" % left.get) + " + (((cpu.F & (1 << FLAGC)) != 0) << 7)" +
-                         " + ((%s & 1) << 8)" % (left.get))
+            code.addline(
+                ("t = (%s >> 1)" % left.get)
+                + " + (((cpu.F & (1 << FLAGC)) != 0) << 7)"
+                + " + ((%s & 1) << 8)" % (left.get)
+            )
         else:
             # Trigger "overflow" for carry flag
             code.addline("t = (%s >> 1) + ((%s & 1) << 7)" % (left.get, left.get) + " + ((%s & 1) << 8)" % (left.get))
@@ -1137,9 +1177,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code
@@ -1177,9 +1217,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code.getcode()
@@ -1198,9 +1238,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code.getcode()
@@ -1217,9 +1257,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code.getcode()
@@ -1235,9 +1275,9 @@ class OpcodeData:
         if left.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(left.set % "t")
         return code.getcode()
@@ -1257,7 +1297,7 @@ class OpcodeData:
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 12 - 4
+            code.cycles = ("8",)  # 12 - 4
 
         code.addline("t = %s & (1 << %s)" % (right.get, left.get))
         code.addlines(self.handleflags8bit(left.get, right.get, None, False))
@@ -1275,9 +1315,9 @@ class OpcodeData:
         if right.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(right.set % "t")
         return code.getcode()
@@ -1292,9 +1332,9 @@ class OpcodeData:
         if right.operand == "(HL)":
             # HACK: Offset the timing by 4 cycles
             # TODO: Probably should be generalized
-            code.lines.insert(0, "cpu.cycles += 4") # Inject before read
+            code.lines.insert(0, "cpu.cycles += 4")  # Inject before read
             code.addline("cpu.cycles += 4")
-            code.cycles = ("8", ) # 16 - 4 - 4
+            code.cycles = ("8",)  # 16 - 4 - 4
 
         code.addline(right.set % "t")
         return code.getcode()
@@ -1356,8 +1396,14 @@ def execute_opcode(cpu, opcode):
         for i, t in enumerate(lookuplist):
             t = t if t is not None else (0, "no_opcode", "")
             f.write(
-                " "*indent + ("if" if i == 0 else "elif") + " opcode == 0x%0.2X:\n"%i + " " * (indent+4) + "return " +
-                str(t[1]).replace("'", "") + ("(cpu)" if t[0] <= 1 else "(cpu, v)") + "\n"
+                " " * indent
+                + ("if" if i == 0 else "elif")
+                + " opcode == 0x%0.2X:\n" % i
+                + " " * (indent + 4)
+                + "return "
+                + str(t[1]).replace("'", "")
+                + ("(cpu)" if t[0] <= 1 else "(cpu, v)")
+                + "\n"
             )
         f.write("\n\n")
 
@@ -1365,8 +1411,8 @@ def execute_opcode(cpu, opcode):
         for i, t in enumerate(lookuplist):
             t = t if t is not None else (0, "no_opcode", "")
             f.write(str(t[0]).replace("'", "") + ",")
-            if (i+1) % 16 == 0:
-                f.write("\n" + " "*4)
+            if (i + 1) % 16 == 0:
+                f.write("\n" + " " * 4)
             else:
                 f.write(" ")
 
@@ -1376,7 +1422,7 @@ def execute_opcode(cpu, opcode):
         f.write("CPU_COMMANDS = [\n    ")
         for _, t in enumerate(lookuplist):
             t = t if t is not None else (0, "no_opcode", "")
-            f.write(f"\"{t[2]}\",\n" + " "*4)
+            f.write(f'"{t[2]}",\n' + " " * 4)
 
         f.write("]\n")
 

--- a/pyboy/core/opcodes_gen.py
+++ b/pyboy/core/opcodes_gen.py
@@ -303,7 +303,6 @@ class OpcodeData:
         self.is16bit = bit16
 
         # TODO: There's no need for this to be so explicit
-        # yapf: disable
         self.functionhandlers = {
             "NOP"    : self.NOP,
             "HALT"   : self.HALT,
@@ -351,7 +350,6 @@ class OpcodeData:
             "RES"    : self.RES,
             "SET"    : self.SET,
         }
-        # yapf: enable
 
     def createfunction(self):
         text = self.functionhandlers[self.name.split()[0]]()

--- a/pyboy/core/ram.py
+++ b/pyboy/core/ram.py
@@ -7,8 +7,8 @@ from array import array
 from random import getrandbits
 
 # MEMORY SIZES
-INTERNAL_RAM0 = 8 * 1024 # 8KiB
-INTERNAL_RAM0_CGB = INTERNAL_RAM0 * 4 # 8 banks of 4KiB
+INTERNAL_RAM0 = 8 * 1024  # 8KiB
+INTERNAL_RAM0_CGB = INTERNAL_RAM0 * 4  # 8 banks of 4KiB
 NON_IO_INTERNAL_RAM0 = 0x60
 IO_PORTS = 0x4C
 NON_IO_INTERNAL_RAM1 = 0x34

--- a/pyboy/core/timer.py
+++ b/pyboy/core/timer.py
@@ -19,8 +19,8 @@
 
 class Timer:
     def __init__(self):
-        self.DIV = 0 # Always showing self.counter with mode 3 divider
-        self.TIMA = 0 # Can be set from RAM 0xFF05
+        self.DIV = 0  # Always showing self.counter with mode 3 divider
+        self.TIMA = 0  # Can be set from RAM 0xFF05
         self.DIV_counter = 0
         self.TIMA_counter = 0
         self.TMA = 0
@@ -42,11 +42,11 @@ class Timer:
         self.last_cycles = _cycles
 
         self.DIV_counter += cycles
-        self.DIV += (self.DIV_counter >> 8) # Add overflown bits to DIV
-        self.DIV_counter &= 0xFF # Remove the overflown bits
+        self.DIV += self.DIV_counter >> 8  # Add overflown bits to DIV
+        self.DIV_counter &= 0xFF  # Remove the overflown bits
         self.DIV &= 0xFF
 
-        if self.TAC & 0b100 == 0: # Check if timer is not enabled
+        if self.TAC & 0b100 == 0:  # Check if timer is not enabled
             self._cycles_to_interrupt = 1 << 16
             return False
 
@@ -55,7 +55,7 @@ class Timer:
 
         ret = False
         while self.TIMA_counter >= (1 << divider):
-            self.TIMA_counter -= (1 << divider) # Keeps possible remainder
+            self.TIMA_counter -= 1 << divider  # Keeps possible remainder
             self.TIMA += 1
 
             if self.TIMA > 0xFF:

--- a/pyboy/logging/__init__.py
+++ b/pyboy/logging/__init__.py
@@ -1,4 +1,10 @@
-DEBUG, INFO, WARNING, ERROR, CRITICAL, = range(5)
+(
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    CRITICAL,
+) = range(5)
 
 _log_level = ERROR
 

--- a/pyboy/plugins/base_plugin.py
+++ b/pyboy/plugins/base_plugin.py
@@ -261,9 +261,12 @@ class PyBoyGameWrapper(PyBoyPlugin):
         for s in sprites:
             _x = (s.x // 8) - xx
             _y = (s.y // 8) - yy
-            if 0 <= _y < height and 0 <= _x < width:
-                tiles_matrix[_y][_x] = self.mapping[
-                    s.tile_identifier] + self.sprite_offset # Adding offset to try to seperate sprites from tiles
+            if 0 <= _x < width:
+                if 0 <= _y < height:
+                    tiles_matrix[_y][_x] = self.mapping[s.tile_identifier] + self.sprite_offset
+                if len(s.tiles) == 2 and 0 <= _y + 1 < height:  # Sprite has two tiles
+                    tiles_matrix[_y + 1][_x] = self.mapping[s.tile_identifier + 1] + self.sprite_offset
+
         return tiles_matrix
 
     def game_area_mapping(self, mapping, sprite_offest):

--- a/pyboy/plugins/base_plugin.py
+++ b/pyboy/plugins/base_plugin.py
@@ -284,7 +284,6 @@ class PyBoyGameWrapper(PyBoyPlugin):
 
     def __repr__(self):
         adjust = 4
-        # yapf: disable
 
         sprites = "\n".join([str(s) for s in self._sprites_on_screen()])
 
@@ -309,4 +308,3 @@ class PyBoyGameWrapper(PyBoyPlugin):
             "\n" +
             tiles
         )
-        # yapf: enable

--- a/pyboy/plugins/base_plugin.py
+++ b/pyboy/plugins/base_plugin.py
@@ -25,6 +25,7 @@ logger = pyboy.logging.get_logger(__name__)
 
 try:
     from cython import compiled
+
     cythonmode = compiled
 except ImportError:
     cythonmode = False
@@ -86,9 +87,9 @@ class PyBoyWindowPlugin(PyBoyPlugin):
         self.renderer = self.mb.lcd.renderer
 
     def frame_limiter(self, speed):
-        self._ftime += int((1.0 / (60.0*speed)) * 1_000_000_000)
+        self._ftime += int((1.0 / (60.0 * speed)) * 1_000_000_000)
         now = time.perf_counter_ns()
-        if (self._ftime > now):
+        if self._ftime > now:
             delay = (self._ftime - now) // 1_000_000
             time.sleep(delay / 1000)
         else:
@@ -111,6 +112,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
     """
     Example mapping of 1:1
     """
+
     def __init__(self, *args, game_area_section=(0, 0, 32, 32), game_area_follow_scxy=False, **kwargs):
         super().__init__(*args, **kwargs)
         if not cythonmode:
@@ -135,7 +137,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
         """
         self._set_dimensions(*game_area_section, game_area_follow_scxy)
         width, height = self.shape
-        self._cached_game_area_tiles_raw = array("B", [0xFF] * (width*height*4))
+        self._cached_game_area_tiles_raw = array("B", [0xFF] * (width * height * 4))
         self._cached_game_area_tiles = memoryview(self._cached_game_area_tiles_raw).cast("I", shape=(width, height))
 
         self.saved_state = io.BytesIO()
@@ -216,11 +218,11 @@ class PyBoyGameWrapper(PyBoyPlugin):
             if self.game_area_follow_scxy:
                 self._cached_game_area_tiles = np.ndarray(shape=(height, width), dtype=np.uint32)
                 for y in range(height):
-                    SCX = scanline_parameters[(yy+y) * 8][0] // 8
-                    SCY = scanline_parameters[(yy+y) * 8][1] // 8
+                    SCX = scanline_parameters[(yy + y) * 8][0] // 8
+                    SCY = scanline_parameters[(yy + y) * 8][1] // 8
                     for x in range(width):
-                        _x = (xx+x+SCX) % 32
-                        _y = (yy+y+SCY) % 32
+                        _x = (xx + x + SCX) % 32
+                        _y = (yy + y + SCY) % 32
                         if self.tilemap_use_background:
                             self._cached_game_area_tiles[y, x] = self.tilemap_background.tile_identifier(_x, _y)
                         else:
@@ -228,11 +230,11 @@ class PyBoyGameWrapper(PyBoyPlugin):
             else:
                 if self.tilemap_use_background:
                     self._cached_game_area_tiles = np.asarray(
-                        self.tilemap_background[xx:xx + width, yy:yy + height], dtype=np.uint32
+                        self.tilemap_background[xx : xx + width, yy : yy + height], dtype=np.uint32
                     )
                 else:
                     self._cached_game_area_tiles = np.asarray(
-                        self.tilemap_window[xx:xx + width, yy:yy + height], dtype=np.uint32
+                        self.tilemap_window[xx : xx + width, yy : yy + height], dtype=np.uint32
                     )
             self._tile_cache_invalid = False
         return self._cached_game_area_tiles
@@ -274,9 +276,9 @@ class PyBoyGameWrapper(PyBoyPlugin):
 
     def _sum_number_on_screen(self, x, y, length, blank_tile_identifier, tile_identifier_offset):
         number = 0
-        for i, x in enumerate(self.tilemap_background[x:x + length, y]):
+        for i, x in enumerate(self.tilemap_background[x : x + length, y]):
             if x != blank_tile_identifier:
-                number += (x+tile_identifier_offset) * (10**(length - 1 - i))
+                number += (x + tile_identifier_offset) * (10 ** (length - 1 - i))
         return number
 
     def __repr__(self):
@@ -285,23 +287,14 @@ class PyBoyGameWrapper(PyBoyPlugin):
         sprites = "\n".join([str(s) for s in self._sprites_on_screen()])
 
         tiles_header = (
-            " "*4 + "".join([f"{i: >4}" for i in range(self.shape[0])]) + "\n" +
-            "_"*(adjust*self.shape[0]+4)
+            " " * 4 + "".join([f"{i: >4}" for i in range(self.shape[0])]) + "\n" + "_" * (adjust * self.shape[0] + 4)
         )
 
         tiles = "\n".join(
-                [
-                    (f"{i: <3}|" + "".join([str(tile).rjust(adjust) for tile in line])).strip()
-                    for i, line in enumerate(self.game_area())
-                ]
-            )
-
-        return (
-            "Sprites on screen:\n" +
-            sprites +
-            "\n" +
-            "Tiles on screen:\n" +
-            tiles_header +
-            "\n" +
-            tiles
+            [
+                (f"{i: <3}|" + "".join([str(tile).rjust(adjust) for tile in line])).strip()
+                for i, line in enumerate(self.game_area())
+            ]
         )
+
+        return "Sprites on screen:\n" + sprites + "\n" + "Tiles on screen:\n" + tiles_header + "\n" + tiles

--- a/pyboy/plugins/base_plugin.py
+++ b/pyboy/plugins/base_plugin.py
@@ -19,7 +19,7 @@ from array import array
 import numpy as np
 
 import pyboy
-from pyboy.api.sprite import Sprite
+from pyboy.api.constants import SPRITES, TILES_CGB
 
 logger = pyboy.logging.get_logger(__name__)
 
@@ -107,7 +107,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
 
     cartridge_title = None
 
-    mapping_one_to_one = np.arange(384 * 2, dtype=np.uint8)
+    mapping_one_to_one = np.arange(TILES_CGB, dtype=np.uint8)
     """
     Example mapping of 1:1
     """
@@ -117,7 +117,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
             self.tilemap_background = self.pyboy.tilemap_background
             self.tilemap_window = self.pyboy.tilemap_window
         self.tilemap_use_background = True
-        self.mapping = np.asarray([x for x in range(768)], dtype=np.uint32)
+        self.mapping = np.arange(TILES_CGB, dtype=np.uint32)
         self.sprite_offset = 0
         self.game_has_started = False
         self._tile_cache_invalid = True
@@ -201,8 +201,8 @@ class PyBoyGameWrapper(PyBoyPlugin):
     def _sprites_on_screen(self):
         if self._sprite_cache_invalid:
             self._cached_sprites_on_screen = []
-            for s in range(40):
-                sprite = Sprite(self.mb, s)
+            for s in range(SPRITES):
+                sprite = self.pyboy.get_sprite(s)
                 if sprite.on_screen:
                     self._cached_sprites_on_screen.append(sprite)
             self._sprite_cache_invalid = False
@@ -210,10 +210,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
 
     def _game_area_tiles(self):
         if self._tile_cache_invalid:
-            xx = self.game_area_section[0]
-            yy = self.game_area_section[1]
-            width = self.game_area_section[2]
-            height = self.game_area_section[3]
+            xx, yy, width, height = self.game_area_section
             scanline_parameters = self.pyboy.screen.tilemap_position_list
 
             if self.game_area_follow_scxy:
@@ -254,10 +251,7 @@ class PyBoyGameWrapper(PyBoyPlugin):
         """
         tiles_matrix = self.mapping[self._game_area_tiles()]
         sprites = self._sprites_on_screen()
-        xx = self.game_area_section[0]
-        yy = self.game_area_section[1]
-        width = self.game_area_section[2]
-        height = self.game_area_section[3]
+        xx, yy, width, height = self.game_area_section
         for s in sprites:
             _x = (s.x // 8) - xx
             _y = (s.y // 8) - yy

--- a/pyboy/plugins/debug.py
+++ b/pyboy/plugins/debug.py
@@ -18,6 +18,7 @@ from pyboy.utils import WindowEvent
 
 try:
     from cython import compiled
+
     cythonmode = compiled
 except ImportError:
     cythonmode = False
@@ -55,7 +56,7 @@ class MarkedTile:
         mark_id="",
         mark_color=0,
         sprite_height=8,
-        sprite=False
+        sprite=False,
     ):
         self.tile_identifier = tile_identifier
         self.mark_id = mark_id
@@ -103,9 +104,9 @@ class Debug(PyBoyWindowPlugin):
             pos_y=0,
             window_map=False,
             scanline_x=0,
-            scanline_y=1
+            scanline_y=1,
         )
-        window_pos += (256 * self.tile1.scale)
+        window_pos += 256 * self.tile1.scale
 
         self.tile2 = TileViewWindow(
             pyboy,
@@ -119,9 +120,9 @@ class Debug(PyBoyWindowPlugin):
             pos_y=0,
             window_map=True,
             scanline_x=2,
-            scanline_y=3
+            scanline_y=3,
         )
-        window_pos += (256 * self.tile2.scale)
+        window_pos += 256 * self.tile2.scale
 
         self.spriteview = SpriteViewWindow(
             pyboy,
@@ -132,7 +133,7 @@ class Debug(PyBoyWindowPlugin):
             width=constants.COLS,
             height=constants.ROWS,
             pos_x=window_pos,
-            pos_y=0
+            pos_y=0,
         )
 
         self.sprite = SpriteWindow(
@@ -144,9 +145,9 @@ class Debug(PyBoyWindowPlugin):
             width=8 * 10,
             height=16 * 4,
             pos_x=window_pos,
-            pos_y=self.spriteview.height * 2 + 68
+            pos_y=self.spriteview.height * 2 + 68,
         )
-        window_pos += (constants.COLS * self.spriteview.scale)
+        window_pos += constants.COLS * self.spriteview.scale
 
         self.memory = MemoryWindow(
             pyboy, mb, pyboy_argv, scale=1, title="Memory", width=8 * 60, height=16 * 36, pos_x=window_pos, pos_y=0
@@ -154,7 +155,7 @@ class Debug(PyBoyWindowPlugin):
         window_pos += 8 * 60
 
         window_pos = 0
-        tile_data_width = 16 * 8 # Change the 16 to however wide you want the tile window
+        tile_data_width = 16 * 8  # Change the 16 to however wide you want the tile window
         tile_data_height = ((constants.TILES * 8) // tile_data_width) * 8
         self.tiledata0 = TileDataWindow(
             pyboy,
@@ -165,7 +166,7 @@ class Debug(PyBoyWindowPlugin):
             width=tile_data_width,
             height=tile_data_height,
             pos_x=window_pos,
-            pos_y=(256 * self.tile1.scale) + 128
+            pos_y=(256 * self.tile1.scale) + 128,
         )
         if self.cgb:
             window_pos += 512
@@ -178,7 +179,7 @@ class Debug(PyBoyWindowPlugin):
                 width=tile_data_width,
                 height=tile_data_height,
                 pos_x=window_pos,
-                pos_y=(256 * self.tile1.scale) + 128
+                pos_y=(256 * self.tile1.scale) + 128,
             )
 
     def post_tick(self):
@@ -226,7 +227,7 @@ class Debug(PyBoyWindowPlugin):
 
 
 def make_buffer(w, h, depth=4):
-    buf = array("B", [0x55] * (w*h*depth))
+    buf = array("B", [0x55] * (w * h * depth))
     if depth == 4:
         buf0 = memoryview(buf).cast("I", shape=(h, w))
     else:
@@ -292,14 +293,14 @@ class BaseDebugWindow(PyBoyWindowPlugin):
             _y = 7 - y if vflip else y
             for x in range(8):
                 _x = 7 - x if hflip else x
-                to_buffer[yy + y, xx + x] = palette[from_buffer[_y + t*8, _x]]
+                to_buffer[yy + y, xx + x] = palette[from_buffer[_y + t * 8, _x]]
 
     def mark_tile(self, x, y, color, height, width, grid):
-        tw = width # Tile width
-        th = height # Tile height
+        tw = width  # Tile width
+        th = height  # Tile height
         if grid:
-            xx = x - (x%tw)
-            yy = y - (y%th)
+            xx = x - (x % tw)
+            yy = y - (y % th)
         else:
             xx = x
             yy = y
@@ -337,8 +338,8 @@ class TileViewWindow(BaseDebugWindow):
                 # (x ^ 0x80 - 128) to convert to signed, then add 256 for offset (reduces to + 128)
                 tile_index = (tile_index ^ 0x80) + 128
 
-            tile_column = (n-mem_offset) % 32
-            tile_row = (n-mem_offset) // 32
+            tile_column = (n - mem_offset) % 32
+            tile_row = (n - mem_offset) // 32
 
             # tilecache = None
             # palette_rgb = None
@@ -347,8 +348,8 @@ class TileViewWindow(BaseDebugWindow):
                     self.mb.lcd, n
                 )
                 self.renderer.update_tilecache1(self.mb.lcd, tile_index, 1)
-                self.tilecache = (self.renderer._tilecache1 if vbank else self.renderer._tilecache0)
-                self.palette_rgb = self.mb.lcd.ocpd.palette_mem_rgb # TODO: Select palette by adding offset
+                self.tilecache = self.renderer._tilecache1 if vbank else self.renderer._tilecache0
+                self.palette_rgb = self.mb.lcd.ocpd.palette_mem_rgb  # TODO: Select palette by adding offset
             else:
                 # Fake palette index
                 palette = 0
@@ -358,8 +359,14 @@ class TileViewWindow(BaseDebugWindow):
                 self.palette_rgb = self.mb.lcd.BGP.palette_mem_rgb
 
             self.copy_tile(
-                self.tilecache, tile_index, tile_column * 8, tile_row * 8, self.buf0, horiflip, vertflip,
-                self.palette_rgb
+                self.tilecache,
+                tile_index,
+                tile_column * 8,
+                tile_row * 8,
+                self.buf0,
+                horiflip,
+                vertflip,
+                self.palette_rgb,
             )
 
         self.draw_overlay()
@@ -390,10 +397,16 @@ class TileViewWindow(BaseDebugWindow):
 
     def update_title(self):
         title = self.base_title
-        title += " [HIGH MAP 0x9C00-0x9FFF]" if self.tilemap.map_offset == constants.HIGH_TILEMAP else \
-            " [LOW MAP 0x9800-0x9BFF]"
-        title += " [HIGH DATA (SIGNED) 0x8800-0x97FF]" if self.tilemap.signed_tile_data else \
-            " [LOW DATA (UNSIGNED) 0x8000-0x8FFF]"
+        title += (
+            " [HIGH MAP 0x9C00-0x9FFF]"
+            if self.tilemap.map_offset == constants.HIGH_TILEMAP
+            else " [LOW MAP 0x9800-0x9BFF]"
+        )
+        title += (
+            " [HIGH DATA (SIGNED) 0x8800-0x97FF]"
+            if self.tilemap.signed_tile_data
+            else " [LOW DATA (UNSIGNED) 0x8000-0x8FFF]"
+        )
         if self.tilemap._select == "WINDOW":
             title += " [Window]"
         if self.tilemap._select == "BACKGROUND":
@@ -412,25 +425,25 @@ class TileViewWindow(BaseDebugWindow):
             xx = int(scanlineparameters[y][self.scanline_x])
             yy = int(scanlineparameters[y][self.scanline_y])
 
-            if background_view: # Background
+            if background_view:  # Background
                 # Wraps around edges of the screen
-                if y == 0 or y == constants.ROWS - 1: # Draw top/bottom bar
+                if y == 0 or y == constants.ROWS - 1:  # Draw top/bottom bar
                     for x in range(constants.COLS):
-                        self.buf0[(yy+y) % 0xFF, (xx+x) % 0xFF] = COLOR
-                else: # Draw body
-                    self.buf0[(yy+y) % 0xFF, xx % 0xFF] = COLOR
+                        self.buf0[(yy + y) % 0xFF, (xx + x) % 0xFF] = COLOR
+                else:  # Draw body
+                    self.buf0[(yy + y) % 0xFF, xx % 0xFF] = COLOR
                     for x in range(constants.COLS):
-                        self.buf0[(yy+y) % 0xFF, (xx+x) % 0xFF] &= self.color
-                    self.buf0[(yy+y) % 0xFF, (xx + constants.COLS) % 0xFF] = COLOR
-            else: # Window
+                        self.buf0[(yy + y) % 0xFF, (xx + x) % 0xFF] &= self.color
+                    self.buf0[(yy + y) % 0xFF, (xx + constants.COLS) % 0xFF] = COLOR
+            else:  # Window
                 # Takes a cut of the screen
                 xx = -xx
                 yy = -yy
-                if yy + y == 0 or y == constants.ROWS - 1: # Draw top/bottom bar
+                if yy + y == 0 or y == constants.ROWS - 1:  # Draw top/bottom bar
                     for x in range(constants.COLS):
                         if 0 <= xx + x < constants.COLS:
                             self.buf0[yy + y, xx + x] = COLOR
-                else: # Draw body
+                else:  # Draw body
                     if 0 <= yy + y:
                         self.buf0[yy + y, max(xx, 0)] = COLOR
                         for x in range(constants.COLS):
@@ -469,7 +482,7 @@ class TileDataWindow(BaseDebugWindow):
             tilecache = self.renderer._tilecache0
 
         if self.cgb:
-            self.palette_rgb = self.mb.lcd.bcpd.palette_mem_rgb # TODO: Select palette by adding offset
+            self.palette_rgb = self.mb.lcd.bcpd.palette_mem_rgb  # TODO: Select palette by adding offset
         else:
             self.palette_rgb = self.mb.lcd.BGP.palette_mem_rgb
 
@@ -478,8 +491,8 @@ class TileDataWindow(BaseDebugWindow):
                 self.renderer.update_tilecache1(self.mb.lcd, t, 1)
             else:
                 self.renderer.update_tilecache0(self.mb.lcd, t, 0)
-            xx = (t*8) % self.width
-            yy = ((t*8) // self.width) * 8
+            xx = (t * 8) % self.width
+            yy = ((t * 8) // self.width) * 8
             self.copy_tile(tilecache, t, xx, yy, self.buf0, False, False, self.palette_rgb)
 
         self.draw_overlay()
@@ -517,7 +530,6 @@ class TileDataWindow(BaseDebugWindow):
 
 class SpriteWindow(BaseDebugWindow):
     def post_tick(self):
-
         # TODO: Could we use scanline_sprites with modified arguments to render all of this?
         sprite_height = 16 if self.mb.lcd._LCDC.sprite_height else 8
         for n in range(0, 0xA0, 4):
@@ -525,8 +537,8 @@ class SpriteWindow(BaseDebugWindow):
             # y = lcd.OAM[n+1]
             t = self.mb.lcd.OAM[n + 2]
             attributes = self.mb.lcd.OAM[n + 3]
-            xx = ((n//4) * 8) % self.width
-            yy = (((n//4) * 8) // self.width) * sprite_height
+            xx = ((n // 4) * 8) % self.width
+            yy = (((n // 4) * 8) // self.width) * sprite_height
 
             if self.cgb:
                 palette = attributes & 0b111
@@ -540,7 +552,7 @@ class SpriteWindow(BaseDebugWindow):
                     if self.mb.lcd._LCDC.sprite_height:
                         self.renderer.update_spritecache0(self.mb.lcd, t + 1, 0)
                     self.spritecache = self.renderer._spritecache0
-                self.palette_rgb = self.mb.lcd.ocpd.palette_mem_rgb # TODO: Select palette by adding offset
+                self.palette_rgb = self.mb.lcd.ocpd.palette_mem_rgb  # TODO: Select palette by adding offset
             else:
                 # Fake palette index
                 palette = 0
@@ -604,8 +616,8 @@ class SpriteWindow(BaseDebugWindow):
             marked_tiles, self.pyboy.get_sprite_by_tile_identifier([m.tile_identifier for m in marked_tiles])
         ):
             for sprite_index in matched_sprites:
-                xx = (sprite_index*8) % self.width
-                yy = ((sprite_index*8) // self.width) * sprite_height
+                xx = (sprite_index * 8) % self.width
+                yy = ((sprite_index * 8) // self.width) * sprite_height
                 self.mark_tile(xx, yy, m.mark_color, sprite_height, 8, True)
 
         if self.hover_x != -1:
@@ -663,7 +675,7 @@ class MemoryWindow(BaseDebugWindow):
         font_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "font.txt")
         with open(font_path) as font_file:
             font_lines = font_file.readlines()
-        font_blob = "".join(line.strip() for line in font_lines[font_lines.index("BASE64DATA:\n") + 1:])
+        font_blob = "".join(line.strip() for line in font_lines[font_lines.index("BASE64DATA:\n") + 1 :])
         font_bytes = zlib.decompress(b64decode(font_blob.encode()))
 
         self.fbuf0, self.fbuf_p = make_buffer(8, 16 * 256)
@@ -709,8 +721,7 @@ class MemoryWindow(BaseDebugWindow):
         self.text_buffer[self.NROWS - 1, self.NCOLS - 1] = 0xBC
 
     def write_addresses(self):
-        header = (f"Memory from 0x{self.start_address:04X} "
-                  f"to 0x{self.start_address+0x1FF:04X}").encode("cp437")
+        header = (f"Memory from 0x{self.start_address:04X} " f"to 0x{self.start_address+0x1FF:04X}").encode("cp437")
         for x in range(28):
             self.text_buffer[1, x + 2] = header[x]
         for y in range(32):
@@ -721,10 +732,10 @@ class MemoryWindow(BaseDebugWindow):
     def write_memory(self):
         for y in range(32):
             for x in range(16):
-                mem = self.mb.getitem(self.start_address + 16*y + x)
+                mem = self.mb.getitem(self.start_address + 16 * y + x)
                 a = hex(mem)[2:].zfill(2).encode("cp437")
-                self.text_buffer[y + 3, 3*x + 11] = a[0]
-                self.text_buffer[y + 3, 3*x + 12] = a[1]
+                self.text_buffer[y + 3, 3 * x + 11] = a[0]
+                self.text_buffer[y + 3, 3 * x + 12] = a[1]
 
     def render_text(self):
         for y in range(self.NROWS):
@@ -738,7 +749,7 @@ class MemoryWindow(BaseDebugWindow):
         self.dst.y = y
         for i, c in enumerate(text):
             if not 0 <= c < 256:
-                logger.warning(f"Invalid character {c} in {bytes(text).decode('cp437')}") # This may error too...
+                logger.warning(f"Invalid character {c} in {bytes(text).decode('cp437')}")  # This may error too...
                 c = 0
             self.src.y = 16 * c
             if self.dst.x > self.width - 8:

--- a/pyboy/plugins/debug_prompt.py
+++ b/pyboy/plugins/debug_prompt.py
@@ -107,10 +107,11 @@ class DebugPrompt(PyBoyPlugin):
 
             elif cmd == "d":
                 print(f"Removing breakpoint at current PC")
-                self.mb.breakpoint_reached() # NOTE: This removes the breakpoint we are currently at
+                self.mb.breakpoint_reached()  # NOTE: This removes the breakpoint we are currently at
             elif cmd == "pdb":
                 # Start pdb
                 import pdb
+
                 pdb.set_trace()
                 break
             else:

--- a/pyboy/plugins/game_wrapper_kirby_dream_land.py
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.py
@@ -134,7 +134,6 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         return self._game_over
 
     def __repr__(self):
-        # yapf: disable
         return (
             f"Kirby Dream Land:\n" +
             f"Score: {self.score}\n" +
@@ -142,4 +141,3 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
             f"Lives left: {self.lives_left}\n" +
             super().__repr__()
         )
-        # yapf: enable

--- a/pyboy/plugins/game_wrapper_kirby_dream_land.py
+++ b/pyboy/plugins/game_wrapper_kirby_dream_land.py
@@ -22,6 +22,7 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
 
     If you call `print` on an instance of this object, it will show an overview of everything this object provides.
     """
+
     cartridge_title = "KIRBY DREAM LA"
 
     def __init__(self, *args, **kwargs):
@@ -43,7 +44,7 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         self.score = 0
         score_digits = 4
         for n in range(score_digits):
-            self.score += self.pyboy.memory[0xD070 + n] * 10**(score_digits - n)
+            self.score += self.pyboy.memory[0xD070 + n] * 10 ** (score_digits - n)
 
         # Check if game is over
         prev_health = self.health
@@ -69,7 +70,7 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
         # Boot screen
         while True:
             self.pyboy.tick(1, False)
-            if self.tilemap_background[0:3, 16] == [231, 224, 235]: # 'HAL' on the first screen
+            if self.tilemap_background[0:3, 16] == [231, 224, 235]:  # 'HAL' on the first screen
                 break
 
         # Wait for transition to finish (start screen)
@@ -135,9 +136,9 @@ class GameWrapperKirbyDreamLand(PyBoyGameWrapper):
 
     def __repr__(self):
         return (
-            f"Kirby Dream Land:\n" +
-            f"Score: {self.score}\n" +
-            f"Health: {self.health}\n" +
-            f"Lives left: {self.lives_left}\n" +
-            super().__repr__()
+            f"Kirby Dream Land:\n"
+            + f"Score: {self.score}\n"
+            + f"Health: {self.health}\n"
+            + f"Lives left: {self.lives_left}\n"
+            + super().__repr__()
         )

--- a/pyboy/plugins/game_wrapper_pokemon_gen1.py
+++ b/pyboy/plugins/game_wrapper_pokemon_gen1.py
@@ -24,6 +24,7 @@ class GameWrapperPokemonGen1(PyBoyGameWrapper):
 
     If you call `print` on an instance of this object, it will show an overview of everything this object provides.
     """
+
     cartridge_title = None
 
     def __init__(self, *args, **kwargs):
@@ -63,7 +64,7 @@ class GameWrapperPokemonGen1(PyBoyGameWrapper):
             else:
                 walkable_tiles_indexes.append(tile_index + 0x100)
         screen_tiles = self._get_screen_background_tilemap()
-        bottom_left_screen_tiles = screen_tiles[1:1 + screen_tiles.shape[0]:2, ::2]
+        bottom_left_screen_tiles = screen_tiles[1 : 1 + screen_tiles.shape[0] : 2, ::2]
         walkable_matrix = np.isin(bottom_left_screen_tiles, walkable_tiles_indexes).astype(np.uint8)
         return walkable_matrix
 
@@ -74,8 +75,8 @@ class GameWrapperPokemonGen1(PyBoyGameWrapper):
         _collision = self._get_screen_walkable_matrix()
         for i in range(height // 2):
             for j in range(width // 2):
-                game_area[i * 2][j * 2:j*2 + 2] = _collision[i][j]
-                game_area[i*2 + 1][j * 2:j*2 + 2] = _collision[i][j]
+                game_area[i * 2][j * 2 : j * 2 + 2] = _collision[i][j]
+                game_area[i * 2 + 1][j * 2 : j * 2 + 2] = _collision[i][j]
         return game_area
 
     def __repr__(self):

--- a/pyboy/plugins/game_wrapper_pokemon_gen1.py
+++ b/pyboy/plugins/game_wrapper_pokemon_gen1.py
@@ -79,9 +79,4 @@ class GameWrapperPokemonGen1(PyBoyGameWrapper):
         return game_area
 
     def __repr__(self):
-        # yapf: disable
-        return (
-            f"Pokemon Gen 1:\n" +
-            super().__repr__()
-        )
-        # yapf: enable
+        return "Pokemon Gen 1:\n" + super().__repr__()

--- a/pyboy/plugins/game_wrapper_pokemon_pinball.py
+++ b/pyboy/plugins/game_wrapper_pokemon_pinball.py
@@ -673,8 +673,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         self._update_pokedex()
 
     def __repr__(self):
-        adjust = 4
-        # yapf: disable
+        # fmt: off
         return (
             "PokemonPinball:\n" +
             "Score: " + str(self.score) + "\n" +
@@ -709,7 +708,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
             "Mewtwo stages completed: " + str(self.mewtwo_stages_completed) + " / Visited: " + str(self.mewtwo_stages_visited) + "\n" +
             "Seel stages completed: " + str(self.seel_stages_completed) + " / Visited: " + str(self.seel_stages_visited) + "\n"
         )
-        # yapf: enable
+        # fmt: on
 
     def _add_hooks(self):
         def completed_evolution(context):

--- a/pyboy/plugins/game_wrapper_pokemon_pinball.py
+++ b/pyboy/plugins/game_wrapper_pokemon_pinball.py
@@ -23,6 +23,7 @@ class Stage(Enum):
     """
     The stage values in the game.
     """
+
     RED_TOP = 0
     RED_BOTTOM = 1
     BLUE_TOP = 4
@@ -38,6 +39,7 @@ class Pokemon(Enum):
     """
     The Pokemon values in the game.
     """
+
     BULBASAUR = 0
     IVYSAUR = 1
     VENUSAUR = 2
@@ -195,6 +197,7 @@ class Maps(Enum):
     """
     The map values in the game.
     """
+
     PALLET_TOWN = 0
     VIRIDIAN_CITY = 1
     VIRIDIAN_FOREST = 2
@@ -335,7 +338,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         ##########################
         # Pikachu Saver tracking #
         ##########################
-        self.pikachu_saver_charge = 0 # range of 0-15
+        self.pikachu_saver_charge = 0  # range of 0-15
         """The charge of the Pikachu saver, ranges from 0 to 15"""
         self.pikachu_saver_increments = 0
         """The number of times the Pikachu saver charge has incremented"""
@@ -383,7 +386,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         #######################
         # Extra Ball Tracking #
         #######################
-        self.extra_balls_added = 0 # Does not include extra balls rewarded via roulette
+        self.extra_balls_added = 0  # Does not include extra balls rewarded via roulette
         """The number of extra balls added, not including those rewarded via roulette"""
 
         ##########################
@@ -502,7 +505,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         self.pyboy.memory[ADDR_D5C6] = 0
         self.pyboy.memory[ADDR_NUM_MON_HITS] = 0
         self.pyboy.memory[ADDR_NUM_CATCH_TILES_FLIPPED] = 0
-        self.pyboy.memory[ADDR_TILE_ILLUMINATION:ADDR_TILE_ILLUMINATION + TILE_ILLUMINATION_BYTE_WIDTH] = 0
+        self.pyboy.memory[ADDR_TILE_ILLUMINATION : ADDR_TILE_ILLUMINATION + TILE_ILLUMINATION_BYTE_WIDTH] = 0
         if not unlimited_time:
             self.pyboy.memory[ADDR_TIMER_SECONDS] = 0
             self.pyboy.memory[ADDR_TIMER_MINUTES] = 2
@@ -512,7 +515,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
             self.pyboy.memory[ADDR_TIMER_ACTIVE] = 1
             self.pyboy.memory[ADDR_D580] = 1
 
-    #replaces pause button with evolution start
+    # replaces pause button with evolution start
     def enable_evolve_hack(self, unlimited_time=False):
         """
         Enables the evolution hack in the game.
@@ -545,7 +548,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
             try:
                 self.pyboy.hook_register(bank, offset, disable_timer, self.pyboy)
             except ValueError:
-                pass #hook already exists
+                pass  # hook already exists
 
     def current_map_completed(self):
         """
@@ -615,7 +618,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         ticks_until_input_ready = 4
         self.pyboy.tick(ticks_until_input_ready, False)
 
-        #needs to be called after normal initializations, otherwise it will be overwritten
+        # needs to be called after normal initializations, otherwise it will be overwritten
         self._init_bonus_stage(stage)
 
         PyBoyGameWrapper.start_game(self, timer_div=timer_div)
@@ -649,10 +652,13 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
         self.special_mode = self.pyboy.memory[ADDR_SPECIAL_MODE]
         self.special_mode_active = self.pyboy.memory[ADDR_SPECIAL_MODE_ACTIVE] == 1
 
-        self.score = bcd_to_dec(
-            int.from_bytes(self.pyboy.memory[ADDR_SCORE:ADDR_SCORE + SCORE_BYTE_WIDTH], "little"),
-            byte_width=SCORE_BYTE_WIDTH
-        ) * 10
+        self.score = (
+            bcd_to_dec(
+                int.from_bytes(self.pyboy.memory[ADDR_SCORE : ADDR_SCORE + SCORE_BYTE_WIDTH], "little"),
+                byte_width=SCORE_BYTE_WIDTH,
+            )
+            * 10
+        )
 
         self.multiplier = self.pyboy.memory[ADDR_MULTIPLIER]
 
@@ -715,24 +721,32 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
             context.evolution_success_count += 1
 
         self.pyboy.hook_register(
-            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD[0], BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD[1],
-            completed_evolution, self
+            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD[0],
+            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD[1],
+            completed_evolution,
+            self,
         )
         self.pyboy.hook_register(
-            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD[0], BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD[1],
-            completed_evolution, self
+            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD[0],
+            BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD[1],
+            completed_evolution,
+            self,
         )
 
         def failed_evolution(context):
             context.evolution_failure_count += 1
 
         self.pyboy.hook_register(
-            BANK_OFFSET_FAIL_EVOLUTION_MODE_RED_FIELD[0], BANK_OFFSET_FAIL_EVOLUTION_MODE_RED_FIELD[1],
-            failed_evolution, self
+            BANK_OFFSET_FAIL_EVOLUTION_MODE_RED_FIELD[0],
+            BANK_OFFSET_FAIL_EVOLUTION_MODE_RED_FIELD[1],
+            failed_evolution,
+            self,
         )
         self.pyboy.hook_register(
-            BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD[0], BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD[1],
-            failed_evolution, self
+            BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD[0],
+            BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD[1],
+            failed_evolution,
+            self,
         )
 
         def pokemon_caught(context):
@@ -837,12 +851,16 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
             context.pikachu_saver_increments += 1
 
         self.pyboy.hook_register(
-            BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD[0], BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD[1],
-            pika_saver_increment, self
+            BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD[0],
+            BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD[1],
+            pika_saver_increment,
+            self,
         )
         self.pyboy.hook_register(
-            BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD[0], BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD[1],
-            pika_saver_increment, self
+            BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD[0],
+            BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD[1],
+            pika_saver_increment,
+            self,
         )
 
         def pika_saver_used(context):
@@ -864,12 +882,16 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
                 context.master_ball_upgrades += 1
 
         self.pyboy.hook_register(
-            BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD[0], BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD[1],
-            ball_upgrade_trigger, self
+            BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD[0],
+            BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD[1],
+            ball_upgrade_trigger,
+            self,
         )
         self.pyboy.hook_register(
-            BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD[0], BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD[1],
-            ball_upgrade_trigger, self
+            BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD[0],
+            BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD[1],
+            ball_upgrade_trigger,
+            self,
         )
 
         def extra_ball_added(context):
@@ -877,7 +899,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
 
         self.pyboy.hook_register(BANK_OFFSET_ADD_EXTRA_BALL[0], BANK_OFFSET_ADD_EXTRA_BALL[1], extra_ball_added, self)
 
-        #This prevents slot reward extra ball from being counted as it is mostly RNG based and not a good fitness metric
+        # This prevents slot reward extra ball from being counted as it is mostly RNG based and not a good fitness metric
         def slot_reward_extra_ball(context):
             context.extra_balls_added -= 1
 
@@ -890,11 +912,15 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
 
         self.pyboy.hook_register(
             BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_BLUE[0],
-            BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_BLUE[1], opened_slot_by_getting_4_cave_lights, self
+            BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_BLUE[1],
+            opened_slot_by_getting_4_cave_lights,
+            self,
         )
         self.pyboy.hook_register(
             BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_RED[0],
-            BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_RED[1], opened_slot_by_getting_4_cave_lights, self
+            BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_RED[1],
+            opened_slot_by_getting_4_cave_lights,
+            self,
         )
 
         def slot_reward_roulette(context):
@@ -919,48 +945,48 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
 # RAM Addresses #
 #################
 
-#value starts at 1, increments by 1 for each new ball launch and compares to ADDR_NUM_BALL_LIVES
+# value starts at 1, increments by 1 for each new ball launch and compares to ADDR_NUM_BALL_LIVES
 ADDR_BALLS_LEFT = 0xD49D
 
-#value gets initialized to 3 by red and blue stage initialization code
+# value gets initialized to 3 by red and blue stage initialization code
 ADDR_NUM_BALL_LIVES = 0xD49E
 
 ADDR_BALL_TYPE = 0xD47E
 ADDR_BALL_SIZE = 0xD4C8
-ADDR_EXTRA_BALLS = 0xd49b
+ADDR_EXTRA_BALLS = 0xD49B
 
-ADDR_BALL_X = 0xd4b3
-ADDR_BALL_Y = 0xd4b5
-ADDR_BALL_X_VELOCITY = 0xd4bb
-ADDR_BALL_Y_VELOCITY = 0xd4bd
+ADDR_BALL_X = 0xD4B3
+ADDR_BALL_Y = 0xD4B5
+ADDR_BALL_X_VELOCITY = 0xD4BB
+ADDR_BALL_Y_VELOCITY = 0xD4BD
 
 ADDR_BALL_SAVER_SECONDS_LEFT = 0xD4A4
 
-ADDR_NUM_MON_HITS = 0xd5c0
-ADDR_NUM_CATCH_TILES_FLIPPED = 0xd5b6
-ADDR_TILE_ILLUMINATION = 0xd586
+ADDR_NUM_MON_HITS = 0xD5C0
+ADDR_NUM_CATCH_TILES_FLIPPED = 0xD5B6
+ADDR_TILE_ILLUMINATION = 0xD586
 TILE_ILLUMINATION_BYTE_WIDTH = 48
 
-ADDR_MESSAGE_BUFFER = 0xc600
+ADDR_MESSAGE_BUFFER = 0xC600
 MESSAGE_BUFFER_BYTE_WIDTH = 100
 
-ADDR_WHICH_DIGLETT = 0xd4ed
-ADDR_RIGHT_MAP_MOVE_COUNTER = 0xd4f2
-ADDR_LEFT_MAP_MOVE_COUNTER = 0xd4f0
+ADDR_WHICH_DIGLETT = 0xD4ED
+ADDR_RIGHT_MAP_MOVE_COUNTER = 0xD4F2
+ADDR_LEFT_MAP_MOVE_COUNTER = 0xD4F0
 
-ADDR_TIMER_SECONDS = 0xd57a
-ADDR_TIMER_MINUTES = 0xd57b
-ADDR_TIMER_FRAMES = 0xd57c
-ADDR_TIMER_RAN_OUT = 0xd57e # 1 = ran out
-ADDR_TIMER_PAUSED = 0xd57f # nz = paused
-ADDR_TIMER_ACTIVE = 0xd57d # 1 = active
-ADDR_D580 = 0xd580 # Something to do with the timer, needs to be initialized.
+ADDR_TIMER_SECONDS = 0xD57A
+ADDR_TIMER_MINUTES = 0xD57B
+ADDR_TIMER_FRAMES = 0xD57C
+ADDR_TIMER_RAN_OUT = 0xD57E  # 1 = ran out
+ADDR_TIMER_PAUSED = 0xD57F  # nz = paused
+ADDR_TIMER_ACTIVE = 0xD57D  # 1 = active
+ADDR_D580 = 0xD580  # Something to do with the timer, needs to be initialized.
 
-ADDR_CURRENT_MAP = 0xd54a
+ADDR_CURRENT_MAP = 0xD54A
 
-ADDR_D5C6 = 0xd5c6 # Something to do with the catch mode, needs to be initialized.
+ADDR_D5C6 = 0xD5C6  # Something to do with the catch mode, needs to be initialized.
 
-ADDR_POKEDEX = 0xd962
+ADDR_POKEDEX = 0xD962
 
 ADDR_STAGE_COLLISION_STATE = 0xD4AF
 ADDR_STAGE_COLLISION_STATE_HELPER = 0xD7AD
@@ -968,14 +994,14 @@ ADDR_STAGE_COLLISION_STATE_HELPER = 0xD7AD
 ADDR_CURRENT_STAGE = 0xD4AC
 ADDR_CURRENT_STAGE_BACKUP = 0xD4AD
 
-ADDR_BONUS_STAGE_WON = 0xd49a
+ADDR_BONUS_STAGE_WON = 0xD49A
 
-ADDR_PIKACHU_SAVER_CHARGE = 0xd517
+ADDR_PIKACHU_SAVER_CHARGE = 0xD517
 PIKACHU_SAVER_CHARGE_MAX = 15
 
 ADDR_CURRENT_SLOT_FRAME = 0xD603
-#this is the value needed to properly return to main stage after bonus stage
-#it sets the current slot frame to 7, which is the frame before getting spit out after bonus stage
+# this is the value needed to properly return to main stage after bonus stage
+# it sets the current slot frame to 7, which is the frame before getting spit out after bonus stage
 CURRENT_SLOT_FRAME_VALUE = 0x7
 
 ADDR_SCORE = 0xD46A
@@ -987,11 +1013,11 @@ ADDR_GAME_OVER = 0xD616
 ADDR_MULTIPLIER = 0xD482
 
 ADDR_POKEMON_TO_CATCH = 0xD579
-ADDR_RARE_POKEMON_FLAG = 0xd55b
+ADDR_RARE_POKEMON_FLAG = 0xD55B
 
 ADDR_SPECIAL_MODE = 0xD550
 ADDR_SPECIAL_MODE_ACTIVE = 0xD54B
-ADDR_SPECIAL_MODE_STATE = 0xD54D # 0 = handleEvolutionMode, 1 = CompleteEvolutionMode, 2 = FailEvolutionMode
+ADDR_SPECIAL_MODE_STATE = 0xD54D  # 0 = handleEvolutionMode, 1 = CompleteEvolutionMode, 2 = FailEvolutionMode
 # see here: https://github.com/pret/pokepinball/blob/dcfffa520017ba89108f8be97f51d76c68ea44c9/engine/pinball_game/evolution_mode/evolution_mode_blue_field.asm#L34
 
 #######################
@@ -1002,66 +1028,66 @@ ADDR_TO_NO_OP_STAGE_OVERRIDE = 0x1774 + 37
 ADDR_TO_NO_OP_BANK_STAGE_OVERRIDE = 3
 NO_OP_BYTE_WIDTH_STAGE_OVERRIDE = 11
 
-#Evolution hack related addresses
-BANK_OFFSET_START_EVOLUTION = (4, 0x4ab3)
+# Evolution hack related addresses
+BANK_OFFSET_START_EVOLUTION = (4, 0x4AB3)
 BANK_OFFSET_PAUSE_METHOD_BANK = (3, 0x5954)
 BANK_OFFSET_PAUSE_METHOD_CALL = (3, 0x5956)
 
-BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD = (8, 0x4d30)
-BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD = (8, 0x470b)
-BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD = (8, 0x4d7c)
+BANK_OFFSET_COMPLETE_EVOLUTION_MODE_BLUE_FIELD = (8, 0x4D30)
+BANK_OFFSET_COMPLETE_EVOLUTION_MODE_RED_FIELD = (8, 0x470B)
+BANK_OFFSET_FAIL_EVOLUTION_MODE_BLUE_FIELD = (8, 0x4D7C)
 BANK_OFFSET_FAIL_EVOLUTION_MODE_RED_FIELD = (8, 0x4757)
-BANK_OFFSET_ADD_CAUGHT_POKEMON_TO_PARTY = (4, 0x473d)
+BANK_OFFSET_ADD_CAUGHT_POKEMON_TO_PARTY = (4, 0x473D)
 BANK_OFFSET_SET_POKEMON_SEEN_FLAG = (4, 0x4753)
-BANK_OFFSET_INIT_DIGLETT_BONUS_STAGE = (6, 0x59f2)
+BANK_OFFSET_INIT_DIGLETT_BONUS_STAGE = (6, 0x59F2)
 BANK_OFFSET_INIT_MEOWTH_BONUS_STAGE = (9, 0x4000)
 BANK_OFFSET_INIT_GENGAR_BONUS_STAGE = (6, 0x4099)
-BANK_OFFSET_INIT_SEEL_BONUS_STAGE = (9, 0x5a7c)
-BANK_OFFSET_INIT_MEWTWO_BONUS_STAGE = (6, 0x524f)
-BANK_OFFSET_DIGLETT_STAGE_COMPLETE = (6, 0x6bf2)
-BANK_OFFSET_GENGAR_STAGE_COMPLETE = (6, 0x4a14)
-BANK_OFFSET_MEOWTH_STAGE_COMPLETE = (9, 0x444b)
-BANK_OFFSET_SEEL_STAGE_COMPLETE = (9, 0x5c5a)
-BANK_OFFSET_MEWTWO_STAGE_COMPLETE = (6, 0x565e)
-BANK_OFFSET_MAP_CHANGE_ATTEMPT = (0xc, 0x41ec)
-BANK_OFFSET_MAP_CHANGE_SUCCESS = (0xc, 0x55d5)
-BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD = (0x7, 0x4aff)
-BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD = (0x5, 0x4e8a)
-BANK_OFFSET_PIKA_SAVER_USED_BLUE_FIELD = (0x7, 0x50c9)
+BANK_OFFSET_INIT_SEEL_BONUS_STAGE = (9, 0x5A7C)
+BANK_OFFSET_INIT_MEWTWO_BONUS_STAGE = (6, 0x524F)
+BANK_OFFSET_DIGLETT_STAGE_COMPLETE = (6, 0x6BF2)
+BANK_OFFSET_GENGAR_STAGE_COMPLETE = (6, 0x4A14)
+BANK_OFFSET_MEOWTH_STAGE_COMPLETE = (9, 0x444B)
+BANK_OFFSET_SEEL_STAGE_COMPLETE = (9, 0x5C5A)
+BANK_OFFSET_MEWTWO_STAGE_COMPLETE = (6, 0x565E)
+BANK_OFFSET_MAP_CHANGE_ATTEMPT = (0xC, 0x41EC)
+BANK_OFFSET_MAP_CHANGE_SUCCESS = (0xC, 0x55D5)
+BANK_OFFSET_PIKA_SAVER_INCREMENT_BLUE_FIELD = (0x7, 0x4AFF)
+BANK_OFFSET_PIKA_SAVER_INCREMENT_RED_FIELD = (0x5, 0x4E8A)
+BANK_OFFSET_PIKA_SAVER_USED_BLUE_FIELD = (0x7, 0x50C9)
 BANK_OFFSET_PIKA_SAVER_USED_RED_FIELD = (0x5, 0x6634)
-BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD = (0x7, 0x63de)
-BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD = (0x5, 0x53c0)
-BANK_OFFSET_ADD_EXTRA_BALL = (0xc, 0x4164)
-BANK_OFFSET_SLOT_REWARD_EXTRA_BALL = (0x3, 0x6fa7)
-BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_BLUE = (0x7, 0x667e)
+BANK_OFFSET_BALL_UPGRADE_TRIGGER_BLUE_FIELD = (0x7, 0x63DE)
+BANK_OFFSET_BALL_UPGRADE_TRIGGER_RED_FIELD = (0x5, 0x53C0)
+BANK_OFFSET_ADD_EXTRA_BALL = (0xC, 0x4164)
+BANK_OFFSET_SLOT_REWARD_EXTRA_BALL = (0x3, 0x6FA7)
+BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_BLUE = (0x7, 0x667E)
 BANK_OFFSET_OPENED_SLOT_BY_GETTING_4_CAVE_LIGHTS_RED = (0x5, 0x5284)
-BANK_OFFSET_SLOT_REWARD_ROULETTE = (0x3, 0x6d8e)
-BANK_OFFSET_DISABLE_TIMER = (4, 0x4d64)
-BANK_OFFSET_BALL_SAVED_RED = (3, 0x5d7f)
-BANK_OFFSET_BALL_SAVED_BLUE = (3, 0x5e58)
+BANK_OFFSET_SLOT_REWARD_ROULETTE = (0x3, 0x6D8E)
+BANK_OFFSET_DISABLE_TIMER = (4, 0x4D64)
+BANK_OFFSET_BALL_SAVED_RED = (3, 0x5D7F)
+BANK_OFFSET_BALL_SAVED_BLUE = (3, 0x5E58)
 
 RedStageMapWildMons = {
     Maps.PALLET_TOWN: {
         Pokemon.BULBASAUR: 0.0625,
-        Pokemon.CHARMANDER: .375,
-        Pokemon.PIDGEY: .1875,
-        Pokemon.RATTATA: .1875,
-        Pokemon.NIDORAN_M: .0625,
+        Pokemon.CHARMANDER: 0.375,
+        Pokemon.PIDGEY: 0.1875,
+        Pokemon.RATTATA: 0.1875,
+        Pokemon.NIDORAN_M: 0.0625,
         Pokemon.POLIWAG: 0.0625,
-        Pokemon.TENTACOOL: 0.0625
+        Pokemon.TENTACOOL: 0.0625,
     },
     Maps.VIRIDIAN_FOREST: {
         Pokemon.WEEDLE: 0.3125,
         Pokemon.PIDGEY: 0.3125,
         Pokemon.RATTATA: 0.3125,
-        Pokemon.PIKACHU: 0.0625
+        Pokemon.PIKACHU: 0.0625,
     },
     Maps.PEWTER_CITY: {
         Pokemon.PIDGEY: 0.125,
         Pokemon.SPEAROW: 0.375,
         Pokemon.EKANS: 0.0625,
         Pokemon.JIGGLYPUFF: 0.3125,
-        Pokemon.MAGIKARP: 0.125
+        Pokemon.MAGIKARP: 0.125,
     },
     Maps.CERULEAN_CITY: {
         Pokemon.WEEDLE: 0.125,
@@ -1071,7 +1097,7 @@ RedStageMapWildMons = {
         Pokemon.MANKEY: 0.1875,
         Pokemon.ABRA: 0.125,
         Pokemon.KRABBY: 0.0625,
-        Pokemon.GOLDEEN: 0.0625
+        Pokemon.GOLDEEN: 0.0625,
     },
     Maps.VERMILION_SEASIDE: {
         Pokemon.PIDGEY: 0.0625,
@@ -1081,7 +1107,7 @@ RedStageMapWildMons = {
         Pokemon.MANKEY: 0.125,
         Pokemon.SHELLDER: 0.1875,
         Pokemon.DROWZEE: 0.125,
-        Pokemon.KRABBY: 0.1875
+        Pokemon.KRABBY: 0.1875,
     },
     Maps.ROCK_MOUNTAIN: {
         Pokemon.RATTATA: 0.0625,
@@ -1093,7 +1119,7 @@ RedStageMapWildMons = {
         Pokemon.GEODUDE: 0.0625,
         Pokemon.SLOWPOKE: 0.0625,
         Pokemon.ONIX: 0.0625,
-        Pokemon.VOLTORB: 0.1875
+        Pokemon.VOLTORB: 0.1875,
     },
     Maps.LAVENDER_TOWN: {
         Pokemon.PIDGEY: 0.125,
@@ -1102,7 +1128,7 @@ RedStageMapWildMons = {
         Pokemon.GROWLITHE: 0.125,
         Pokemon.MAGNEMITE: 0.125,
         Pokemon.GASTLY: 0.3125,
-        Pokemon.CUBONE: 0.0625
+        Pokemon.CUBONE: 0.0625,
     },
     Maps.CYCLING_ROAD: {
         Pokemon.RATTATA: 0.125,
@@ -1112,14 +1138,9 @@ RedStageMapWildMons = {
         Pokemon.KRABBY: 0.125,
         Pokemon.LICKITUNG: 0.0625,
         Pokemon.GOLDEEN: 0.125,
-        Pokemon.MAGIKARP: 0.125
+        Pokemon.MAGIKARP: 0.125,
     },
-    Maps.SAFARI_ZONE: {
-        Pokemon.NIDORAN_M: 0.25,
-        Pokemon.PARAS: 0.25,
-        Pokemon.DODUO: 0.25,
-        Pokemon.RHYHORN: 0.25
-    },
+    Maps.SAFARI_ZONE: {Pokemon.NIDORAN_M: 0.25, Pokemon.PARAS: 0.25, Pokemon.DODUO: 0.25, Pokemon.RHYHORN: 0.25},
     Maps.SEAFOAM_ISLANDS: {
         Pokemon.ZUBAT: 0.0625,
         Pokemon.PSYDUCK: 0.0625,
@@ -1130,14 +1151,14 @@ RedStageMapWildMons = {
         Pokemon.KRABBY: 0.0625,
         Pokemon.HORSEA: 0.25,
         Pokemon.GOLDEEN: 0.0625,
-        Pokemon.STARYU: 0.25
+        Pokemon.STARYU: 0.25,
     },
     Maps.CINNABAR_ISLAND: {
         Pokemon.GROWLITHE: 0.25,
         Pokemon.PONYTA: 0.25,
         Pokemon.GRIMER: 0.125,
         Pokemon.KOFFING: 0.25,
-        Pokemon.TANGELA: 0.125
+        Pokemon.TANGELA: 0.125,
     },
     Maps.INDIGO_PLATEAU: {
         Pokemon.SPEAROW: 0.0625,
@@ -1146,8 +1167,8 @@ RedStageMapWildMons = {
         Pokemon.MACHOP: 0.1875,
         Pokemon.GEODUDE: 0.1875,
         Pokemon.ONIX: 0.1875,
-        Pokemon.DITTO: 0.1875
-    }
+        Pokemon.DITTO: 0.1875,
+    },
 }
 """The wild Pokemon that can be found in each map in the Red stage, along with their encounter rates"""
 
@@ -1159,21 +1180,21 @@ RedStageMapWildMonsRare = {
         Pokemon.RATTATA: 0.0625,
         Pokemon.NIDORAN_M: 0.1875,
         Pokemon.POLIWAG: 0.25,
-        Pokemon.TENTACOOL: 0.1875
+        Pokemon.TENTACOOL: 0.1875,
     },
     Maps.VIRIDIAN_FOREST: {
         Pokemon.CATERPIE: 0.125,
         Pokemon.WEEDLE: 0.1875,
         Pokemon.PIDGEY: 0.125,
         Pokemon.RATTATA: 0.125,
-        Pokemon.PIKACHU: 0.4375
+        Pokemon.PIKACHU: 0.4375,
     },
     Maps.PEWTER_CITY: {
         Pokemon.PIDGEY: 0.125,
         Pokemon.SPEAROW: 0.1875,
         Pokemon.EKANS: 0.25,
         Pokemon.JIGGLYPUFF: 0.1875,
-        Pokemon.MAGIKARP: 0.25
+        Pokemon.MAGIKARP: 0.25,
     },
     Maps.CERULEAN_CITY: {
         Pokemon.CATERPIE: 0.0625,
@@ -1184,7 +1205,7 @@ RedStageMapWildMonsRare = {
         Pokemon.ABRA: 0.1875,
         Pokemon.KRABBY: 0.0625,
         Pokemon.GOLDEEN: 0.125,
-        Pokemon.JYNX: 0.1875
+        Pokemon.JYNX: 0.1875,
     },
     Maps.VERMILION_SEASIDE: {
         Pokemon.EKANS: 0.25,
@@ -1193,7 +1214,7 @@ RedStageMapWildMonsRare = {
         Pokemon.FARFETCH_D: 0.25,
         Pokemon.SHELLDER: 0.125,
         Pokemon.DROWZEE: 0.125,
-        Pokemon.KRABBY: 0.125
+        Pokemon.KRABBY: 0.125,
     },
     Maps.ROCK_MOUNTAIN: {
         Pokemon.ZUBAT: 0.125,
@@ -1203,7 +1224,7 @@ RedStageMapWildMonsRare = {
         Pokemon.SLOWPOKE: 0.125,
         Pokemon.ONIX: 0.125,
         Pokemon.VOLTORB: 0.125,
-        Pokemon.MR_MIME: 0.1875
+        Pokemon.MR_MIME: 0.1875,
     },
     Maps.LAVENDER_TOWN: {
         Pokemon.EKANS: 0.0625,
@@ -1213,7 +1234,7 @@ RedStageMapWildMonsRare = {
         Pokemon.GASTLY: 0.125,
         Pokemon.CUBONE: 0.1875,
         Pokemon.ELECTABUZZ: 0.1875,
-        Pokemon.ZAPDOS: 0.1875
+        Pokemon.ZAPDOS: 0.1875,
     },
     Maps.CYCLING_ROAD: {
         Pokemon.TENTACOOL: 0.0625,
@@ -1222,7 +1243,7 @@ RedStageMapWildMonsRare = {
         Pokemon.LICKITUNG: 0.25,
         Pokemon.GOLDEEN: 0.0625,
         Pokemon.MAGIKARP: 0.0625,
-        Pokemon.SNORLAX: 0.1875
+        Pokemon.SNORLAX: 0.1875,
     },
     Maps.SAFARI_ZONE: {
         Pokemon.NIDORAN_M: 0.125,
@@ -1231,14 +1252,9 @@ RedStageMapWildMonsRare = {
         Pokemon.CHANSEY: 0.25,
         Pokemon.SCYTHER: 0.125,
         Pokemon.TAUROS: 0.125,
-        Pokemon.DRATINI: 0.125
+        Pokemon.DRATINI: 0.125,
     },
-    Maps.SEAFOAM_ISLANDS: {
-        Pokemon.SEEL: 0.3125,
-        Pokemon.GOLDEEN: 0.25,
-        Pokemon.STARYU: 0.25,
-        Pokemon.ARTICUNO: 0.1875
-    },
+    Maps.SEAFOAM_ISLANDS: {Pokemon.SEEL: 0.3125, Pokemon.GOLDEEN: 0.25, Pokemon.STARYU: 0.25, Pokemon.ARTICUNO: 0.1875},
     Maps.CINNABAR_ISLAND: {
         Pokemon.GROWLITHE: 0.125,
         Pokemon.PONYTA: 0.125,
@@ -1246,7 +1262,7 @@ RedStageMapWildMonsRare = {
         Pokemon.KOFFING: 0.125,
         Pokemon.TANGELA: 0.1875,
         Pokemon.OMANYTE: 0.1875,
-        Pokemon.KABUTO: 0.1875
+        Pokemon.KABUTO: 0.1875,
     },
     Maps.INDIGO_PLATEAU: {
         Pokemon.SPEAROW: 0.0625,
@@ -1258,8 +1274,8 @@ RedStageMapWildMonsRare = {
         Pokemon.DITTO: 0.25,
         Pokemon.MOLTRES: 0.1875,
         Pokemon.MEWTWO: 0.1875,
-        Pokemon.MEW: 0.0625
-    }
+        Pokemon.MEW: 0.0625,
+    },
 }
 """The rare wild Pokemon that can be found in each map in the Red stage, along with their encounter rates"""
 
@@ -1272,13 +1288,13 @@ BlueStageMapWildMons = {
         Pokemon.NIDORAN_M: 0.1875,
         Pokemon.POLIWAG: 0.0625,
         Pokemon.TENTACOOL: 0.0625,
-        Pokemon.GOLDEEN: 0.0625
+        Pokemon.GOLDEEN: 0.0625,
     },
     Maps.VIRIDIAN_FOREST: {
         Pokemon.CATERPIE: 0.3125,
         Pokemon.PIDGEY: 0.3125,
         Pokemon.RATTATA: 0.3125,
-        Pokemon.PIKACHU: 0.0625
+        Pokemon.PIKACHU: 0.0625,
     },
     Maps.MT_MOON: {
         Pokemon.RATTATA: 0.0625,
@@ -1290,7 +1306,7 @@ BlueStageMapWildMons = {
         Pokemon.PSYDUCK: 0.0625,
         Pokemon.GEODUDE: 0.125,
         Pokemon.KRABBY: 0.0625,
-        Pokemon.GOLDEEN: 0.0625
+        Pokemon.GOLDEEN: 0.0625,
     },
     Maps.CERULEAN_CITY: {
         Pokemon.CATERPIE: 0.125,
@@ -1300,7 +1316,7 @@ BlueStageMapWildMons = {
         Pokemon.ABRA: 0.125,
         Pokemon.BELLSPROUT: 0.3125,
         Pokemon.KRABBY: 0.0625,
-        Pokemon.GOLDEEN: 0.0625
+        Pokemon.GOLDEEN: 0.0625,
     },
     Maps.VERMILION_STREETS: {
         Pokemon.PIDGEY: 0.0625,
@@ -1310,7 +1326,7 @@ BlueStageMapWildMons = {
         Pokemon.BELLSPROUT: 0.125,
         Pokemon.SHELLDER: 0.1875,
         Pokemon.DROWZEE: 0.125,
-        Pokemon.KRABBY: 0.1875
+        Pokemon.KRABBY: 0.1875,
     },
     Maps.ROCK_MOUNTAIN: {
         Pokemon.RATTATA: 0.0625,
@@ -1322,7 +1338,7 @@ BlueStageMapWildMons = {
         Pokemon.GEODUDE: 0.0625,
         Pokemon.SLOWPOKE: 0.0625,
         Pokemon.ONIX: 0.0625,
-        Pokemon.VOLTORB: 0.1875
+        Pokemon.VOLTORB: 0.1875,
     },
     Maps.CELADON_CITY: {
         Pokemon.PIDGEY: 0.125,
@@ -1331,7 +1347,7 @@ BlueStageMapWildMons = {
         Pokemon.MEOWTH: 0.1875,
         Pokemon.MANKEY: 0.1875,
         Pokemon.GROWLITHE: 0.125,
-        Pokemon.BELLSPROUT: 0.125
+        Pokemon.BELLSPROUT: 0.125,
     },
     Maps.FUCHSIA_CITY: {
         Pokemon.VENONAT: 0.125,
@@ -1339,14 +1355,9 @@ BlueStageMapWildMons = {
         Pokemon.EXEGGCUTE: 0.125,
         Pokemon.KANGASKHAN: 0.125,
         Pokemon.GOLDEEN: 0.1875,
-        Pokemon.MAGIKARP: 0.25
+        Pokemon.MAGIKARP: 0.25,
     },
-    Maps.SAFARI_ZONE: {
-        Pokemon.NIDORAN_F: 0.25,
-        Pokemon.PARAS: 0.25,
-        Pokemon.DODUO: 0.25,
-        Pokemon.RHYHORN: 0.25
-    },
+    Maps.SAFARI_ZONE: {Pokemon.NIDORAN_F: 0.25, Pokemon.PARAS: 0.25, Pokemon.DODUO: 0.25, Pokemon.RHYHORN: 0.25},
     Maps.SAFFRON_CITY: {
         Pokemon.PIDGEY: 0.125,
         Pokemon.EKANS: 0.1875,
@@ -1356,14 +1367,14 @@ BlueStageMapWildMons = {
         Pokemon.MEOWTH: 0.0625,
         Pokemon.MANKEY: 0.0625,
         Pokemon.GROWLITHE: 0.0625,
-        Pokemon.BELLSPROUT: 0.125
+        Pokemon.BELLSPROUT: 0.125,
     },
     Maps.CINNABAR_ISLAND: {
         Pokemon.VULPIX: 0.1875,
         Pokemon.PONYTA: 0.3125,
         Pokemon.GRIMER: 0.125,
         Pokemon.KOFFING: 0.25,
-        Pokemon.TANGELA: 0.125
+        Pokemon.TANGELA: 0.125,
     },
     Maps.INDIGO_PLATEAU: {
         Pokemon.SPEAROW: 0.0625,
@@ -1372,8 +1383,8 @@ BlueStageMapWildMons = {
         Pokemon.MACHOP: 0.1875,
         Pokemon.GEODUDE: 0.1875,
         Pokemon.ONIX: 0.1875,
-        Pokemon.DITTO: 0.1875
-    }
+        Pokemon.DITTO: 0.1875,
+    },
 }
 """The wild Pokemon that can be found in each map in the Blue stage, along with their encounter rates"""
 
@@ -1386,14 +1397,14 @@ BlueStageMapWildMonsRare = {
         Pokemon.NIDORAN_M: 0.125,
         Pokemon.POLIWAG: 0.125,
         Pokemon.TENTACOOL: 0.125,
-        Pokemon.GOLDEEN: 0.125
+        Pokemon.GOLDEEN: 0.125,
     },
     Maps.VIRIDIAN_FOREST: {
         Pokemon.CATERPIE: 0.1875,
         Pokemon.WEEDLE: 0.125,
         Pokemon.PIDGEY: 0.125,
         Pokemon.RATTATA: 0.125,
-        Pokemon.PIKACHU: 0.4375
+        Pokemon.PIKACHU: 0.4375,
     },
     Maps.MT_MOON: {
         Pokemon.EKANS: 0.125,
@@ -1401,7 +1412,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.CLEFAIRY: 0.375,
         Pokemon.ZUBAT: 0.125,
         Pokemon.PARAS: 0.125,
-        Pokemon.GEODUDE: 0.125
+        Pokemon.GEODUDE: 0.125,
     },
     Maps.CERULEAN_CITY: {
         Pokemon.WEEDLE: 0.0625,
@@ -1412,7 +1423,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.BELLSPROUT: 0.0625,
         Pokemon.KRABBY: 0.0625,
         Pokemon.GOLDEEN: 0.125,
-        Pokemon.JYNX: 0.1875
+        Pokemon.JYNX: 0.1875,
     },
     Maps.VERMILION_STREETS: {
         Pokemon.SANDSHREW: 0.25,
@@ -1421,7 +1432,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.FARFETCH_D: 0.25,
         Pokemon.SHELLDER: 0.125,
         Pokemon.DROWZEE: 0.125,
-        Pokemon.KRABBY: 0.125
+        Pokemon.KRABBY: 0.125,
     },
     Maps.ROCK_MOUNTAIN: {
         Pokemon.ZUBAT: 0.125,
@@ -1431,7 +1442,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.SLOWPOKE: 0.125,
         Pokemon.ONIX: 0.125,
         Pokemon.VOLTORB: 0.125,
-        Pokemon.MR_MIME: 0.1875
+        Pokemon.MR_MIME: 0.1875,
     },
     Maps.CELADON_CITY: {
         Pokemon.CLEFAIRY: 0.125,
@@ -1440,7 +1451,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.PINSIR: 0.0625,
         Pokemon.EEVEE: 0.1875,
         Pokemon.PORYGON: 0.25,
-        Pokemon.DRATINI: 0.1875
+        Pokemon.DRATINI: 0.1875,
     },
     Maps.FUCHSIA_CITY: {
         Pokemon.VENONAT: 0.25,
@@ -1448,7 +1459,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.EXEGGCUTE: 0.25,
         Pokemon.KANGASKHAN: 0.25,
         Pokemon.GOLDEEN: 0.0625,
-        Pokemon.MAGIKARP: 0.125
+        Pokemon.MAGIKARP: 0.125,
     },
     Maps.SAFARI_ZONE: {
         Pokemon.NIDORAN_F: 0.125,
@@ -1457,7 +1468,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.CHANSEY: 0.25,
         Pokemon.PINSIR: 0.125,
         Pokemon.TAUROS: 0.125,
-        Pokemon.DRATINI: 0.125
+        Pokemon.DRATINI: 0.125,
     },
     Maps.SAFFRON_CITY: {
         Pokemon.PIDGEY: 0.0625,
@@ -1469,7 +1480,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.GROWLITHE: 0.0625,
         Pokemon.HITMONLEE: 0.1875,
         Pokemon.HITMONCHAN: 0.1875,
-        Pokemon.LAPRAS: 0.1875
+        Pokemon.LAPRAS: 0.1875,
     },
     Maps.CINNABAR_ISLAND: {
         Pokemon.VULPIX: 0.0625,
@@ -1478,7 +1489,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.KOFFING: 0.125,
         Pokemon.TANGELA: 0.1875,
         Pokemon.MAGMAR: 0.1875,
-        Pokemon.AERODACTYL: 0.1875
+        Pokemon.AERODACTYL: 0.1875,
     },
     Maps.INDIGO_PLATEAU: {
         Pokemon.SPEAROW: 0.0625,
@@ -1490,7 +1501,7 @@ BlueStageMapWildMonsRare = {
         Pokemon.DITTO: 0.25,
         Pokemon.MOLTRES: 0.1875,
         Pokemon.MEWTWO: 0.1875,
-        Pokemon.MEW: 0.0625
+        Pokemon.MEW: 0.0625,
     },
 }
 """The rare wild Pokemon that can be found in each map in the Blue stage, along with their encounter rates"""

--- a/pyboy/plugins/game_wrapper_super_mario_land.py
+++ b/pyboy/plugins/game_wrapper_super_mario_land.py
@@ -478,7 +478,6 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
         return self.pyboy.memory[0xC0A4] == 0x39
 
     def __repr__(self):
-        # yapf: disable
         return (
             f"Super Mario Land: World {'-'.join([str(i) for i in self.world])}\n"
             f"Coins: {self.coins}\n" +
@@ -488,4 +487,3 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
             f"Level progress: {self.level_progress}\n" +
             super().__repr__()
         )
-        # yapf: enable

--- a/pyboy/plugins/game_wrapper_super_mario_land.py
+++ b/pyboy/plugins/game_wrapper_super_mario_land.py
@@ -36,8 +36,35 @@ lever = [255]
 
 # Solid blocks
 neutral_blocks = [
-    142, 143, 221, 222, 231, 232, 233, 234, 235, 236, 301, 302, 303, 304, 319, 340, 352, 353, 355, 356, 357, 358, 359,
-    360, 361, 362, 381, 382, 383
+    142,
+    143,
+    221,
+    222,
+    231,
+    232,
+    233,
+    234,
+    235,
+    236,
+    301,
+    302,
+    303,
+    304,
+    319,
+    340,
+    352,
+    353,
+    355,
+    356,
+    357,
+    358,
+    359,
+    360,
+    361,
+    362,
+    381,
+    382,
+    383,
 ]
 moving_blocks = [230, 238, 239]
 pushable_blokcs = [128, 130, 354]
@@ -65,8 +92,19 @@ minimal_list = [
     base_scripts + plane + submarine,
     coin + mushroom + heart + star + lever,
     neutral_blocks + moving_blocks + pushable_blokcs + question_block + pipes,
-    goomba + koopa + plant + moth + flying_moth + sphinx + big_sphinx + fist + bill + projectiles + shell + explosion +
-    spike,
+    goomba
+    + koopa
+    + plant
+    + moth
+    + flying_moth
+    + sphinx
+    + big_sphinx
+    + fist
+    + bill
+    + projectiles
+    + shell
+    + explosion
+    + spike,
 ]
 for i, tile_list in enumerate(minimal_list):
     for tile in tile_list:
@@ -74,9 +112,33 @@ for i, tile_list in enumerate(minimal_list):
 
 mapping_compressed = np.zeros(TILES, dtype=np.uint8)
 compressed_list = [
-    base_scripts, plane, submarine, shoots, coin, mushroom, heart, star, lever, neutral_blocks, moving_blocks,
-    pushable_blokcs, question_block, pipes, goomba, koopa, plant, moth, flying_moth, sphinx, big_sphinx, fist, bill,
-    projectiles, shell, explosion, spike
+    base_scripts,
+    plane,
+    submarine,
+    shoots,
+    coin,
+    mushroom,
+    heart,
+    star,
+    lever,
+    neutral_blocks,
+    moving_blocks,
+    pushable_blokcs,
+    question_block,
+    pipes,
+    goomba,
+    koopa,
+    plant,
+    moth,
+    flying_moth,
+    sphinx,
+    big_sphinx,
+    fist,
+    bill,
+    projectiles,
+    shell,
+    explosion,
+    spike,
 ]
 for i, tile_list in enumerate(compressed_list):
     for tile in tile_list:
@@ -143,6 +205,7 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
     ```
 
     """
+
     cartridge_title = "SUPER MARIOLAN"
     mapping_compressed = mapping_compressed
     """
@@ -200,6 +263,7 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
            [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]], dtype=uint32)
     ```
     """
+
     def __init__(self, *args, **kwargs):
         self.world = (0, 0)
         """
@@ -294,7 +358,7 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
         level_block = self.pyboy.memory[0xC0AB]
         mario_x = self.pyboy.memory[0xC202]
         scx = self.pyboy.screen.tilemap_position_list[16][0]
-        self.level_progress = level_block*16 + (scx-7) % 16 + mario_x
+        self.level_progress = level_block * 16 + (scx - 7) % 16 + mario_x
 
     def set_lives_left(self, amount):
         """
@@ -352,8 +416,8 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
             self.pyboy.memory[0, i] = 0x00
 
         patch1 = [
-            0x3E, # LD A, d8
-            (world << 4) | (level & 0x0F), # d8
+            0x3E,  # LD A, d8
+            (world << 4) | (level & 0x0F),  # d8
         ]
 
         for i, byte in enumerate(patch1):
@@ -393,7 +457,7 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
         # Boot screen
         while True:
             self.pyboy.tick(1, False)
-            if self.tilemap_background[6:11, 13] == [284, 285, 266, 283, 285]: # "START" on the main menu
+            if self.tilemap_background[6:11, 13] == [284, 285, 266, 283, 285]:  # "START" on the main menu
                 break
 
         self.pyboy.tick(3, False)
@@ -401,14 +465,15 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
         self.pyboy.tick(1, False)
 
         while True:
-            if unlock_level_select and self.pyboy.frame_count == 71: # An arbitrary frame count, where the write will work
+            if (
+                unlock_level_select and self.pyboy.frame_count == 71
+            ):  # An arbitrary frame count, where the write will work
                 self.pyboy.memory[ADDR_WIN_COUNT] = 2 if unlock_level_select else 0
                 break
             self.pyboy.tick(1, False)
 
             # "MARIO" in the title bar and 0 is placed at score
-            if self.tilemap_background[0:5, 0] == [278, 266, 283, 274, 280] and \
-               self.tilemap_background[5, 1] == 256:
+            if self.tilemap_background[0:5, 0] == [278, 266, 283, 274, 280] and self.tilemap_background[5, 1] == 256:
                 # Game has started
                 break
 
@@ -480,10 +545,10 @@ class GameWrapperSuperMarioLand(PyBoyGameWrapper):
     def __repr__(self):
         return (
             f"Super Mario Land: World {'-'.join([str(i) for i in self.world])}\n"
-            f"Coins: {self.coins}\n" +
-            f"lives_left: {self.lives_left}\n" +
-            f"Score: {self.score}\n" +
-            f"Time left: {self.time_left}\n" +
-            f"Level progress: {self.level_progress}\n" +
-            super().__repr__()
+            f"Coins: {self.coins}\n"
+            + f"lives_left: {self.lives_left}\n"
+            + f"Score: {self.score}\n"
+            + f"Time left: {self.time_left}\n"
+            + f"Level progress: {self.level_progress}\n"
+            + super().__repr__()
         )

--- a/pyboy/plugins/game_wrapper_tetris.py
+++ b/pyboy/plugins/game_wrapper_tetris.py
@@ -250,8 +250,6 @@ class GameWrapperTetris(PyBoyGameWrapper):
         return self.tilemap_background[2, 0] == 135 # The tile that fills up the screen when the game is over
 
     def __repr__(self):
-        adjust = 4
-        # yapf: disable
         return (
             f"Tetris:\n" +
             f"Score: {self.score}\n" +
@@ -259,4 +257,3 @@ class GameWrapperTetris(PyBoyGameWrapper):
             f"Lines: {self.lines}\n" +
             super().__repr__()
         )
-        # yapf: enable

--- a/pyboy/plugins/game_wrapper_tetris.py
+++ b/pyboy/plugins/game_wrapper_tetris.py
@@ -44,9 +44,9 @@ for tiles_type_ID, tiles_type in enumerate(tiles_types):
         mapping_compressed[tile_ID] = tiles_type_ID
 
 # Minimal has 3 id's: Background, Tetromino and "losing tile" (which fills the board when losing)
-mapping_minimal = np.ones(TILES, dtype=np.uint8) # For minimal everything is 1
-mapping_minimal[47] = 0 # Except BLANK which is 0
-mapping_minimal[135] = 2 # And background losing tiles BLACK which is 2
+mapping_minimal = np.ones(TILES, dtype=np.uint8)  # For minimal everything is 1
+mapping_minimal[47] = 0  # Except BLANK which is 0
+mapping_minimal[135] = 2  # And background losing tiles BLACK which is 2
 
 
 class GameWrapperTetris(PyBoyGameWrapper):
@@ -55,6 +55,7 @@ class GameWrapperTetris(PyBoyGameWrapper):
 
     If you call `print` on an instance of this object, it will show an overview of everything this object provides.
     """
+
     cartridge_title = "TETRIS"
     mapping_compressed = mapping_compressed
     """
@@ -64,6 +65,7 @@ class GameWrapperTetris(PyBoyGameWrapper):
     """
     Minimal mapping for `pyboy.PyBoy.game_area_mapping`
     """
+
     def __init__(self, *args, **kwargs):
         self.score = 0
         """The score provided by the game"""
@@ -110,7 +112,7 @@ class GameWrapperTetris(PyBoyGameWrapper):
         # Boot screen
         while True:
             self.pyboy.tick(1, False)
-            if self.tilemap_background[2:9, 14] == [89, 25, 21, 10, 34, 14, 27]: # '1PLAYER' on the first screen
+            if self.tilemap_background[2:9, 14] == [89, 25, 21, 10, 34, 14, 27]:  # '1PLAYER' on the first screen
                 break
 
         # Start game. Just press Start when the game allows us.
@@ -225,17 +227,17 @@ class GameWrapperTetris(PyBoyGameWrapper):
         # ROM0:20B0 F0 AE            ld   a,(ff00+AE)
 
         patch1 = [
-            0x3E, # LD A, Tetromino
-            shape_number, # Tetromino
-            0x00, # NOOP
+            0x3E,  # LD A, Tetromino
+            shape_number,  # Tetromino
+            0x00,  # NOOP
         ]
 
         for i, byte in enumerate(patch1):
             self.pyboy.memory[0, 0x206E + i] = byte
 
         patch2 = [
-            0x3E, # LD A, Tetromino
-            shape_number, # Tetromino
+            0x3E,  # LD A, Tetromino
+            shape_number,  # Tetromino
         ]
 
         for i, byte in enumerate(patch2):
@@ -247,13 +249,13 @@ class GameWrapperTetris(PyBoyGameWrapper):
 
         Game over happens, when the game area is filled with Tetrominos without clearing any rows.
         """
-        return self.tilemap_background[2, 0] == 135 # The tile that fills up the screen when the game is over
+        return self.tilemap_background[2, 0] == 135  # The tile that fills up the screen when the game is over
 
     def __repr__(self):
         return (
-            f"Tetris:\n" +
-            f"Score: {self.score}\n" +
-            f"Level: {self.level}\n" +
-            f"Lines: {self.lines}\n" +
-            super().__repr__()
+            f"Tetris:\n"
+            + f"Score: {self.score}\n"
+            + f"Level: {self.level}\n"
+            + f"Lines: {self.lines}\n"
+            + super().__repr__()
         )

--- a/pyboy/plugins/manager_gen.py
+++ b/pyboy/plugins/manager_gen.py
@@ -8,11 +8,20 @@ import re
 # E.g. DisableInput first
 windows = ["WindowSDL2", "WindowOpenGL", "WindowNull", "Debug"]
 game_wrappers = [
-    "GameWrapperSuperMarioLand", "GameWrapperTetris", "GameWrapperKirbyDreamLand", "GameWrapperPokemonGen1",
-    "GameWrapperPokemonPinball"
+    "GameWrapperSuperMarioLand",
+    "GameWrapperTetris",
+    "GameWrapperKirbyDreamLand",
+    "GameWrapperPokemonGen1",
+    "GameWrapperPokemonPinball",
 ]
 plugins = [
-    "DisableInput", "AutoPause", "RecordReplay", "Rewind", "ScreenRecorder", "ScreenshotRecorder", "DebugPrompt"
+    "DisableInput",
+    "AutoPause",
+    "RecordReplay",
+    "Rewind",
+    "ScreenRecorder",
+    "ScreenshotRecorder",
+    "DebugPrompt",
 ] + game_wrappers
 all_plugins = windows + plugins
 
@@ -40,7 +49,6 @@ if __name__ == "__main__":
 
             # Find place to inject
             if line.strip().startswith("# foreach"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# foreach")
 
@@ -58,7 +66,6 @@ if __name__ == "__main__":
                 lines.append("# foreach end\n")
                 out_lines.extend([indentation + l for l in lines])
             elif line.strip().startswith("# plugins_enabled"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# plugins_enabled")
 
@@ -72,7 +79,6 @@ if __name__ == "__main__":
                 lines.append("# plugins_enabled end\n")
                 out_lines.extend([indentation + l for l in lines])
             elif line.strip().startswith("# yield_plugins"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# yield_plugins")
 
@@ -85,7 +91,6 @@ if __name__ == "__main__":
                 lines.append("# yield_plugins end\n")
                 out_lines.extend([indentation + l for l in lines])
             elif line.strip().startswith("# imports"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# imports")
 
@@ -98,7 +103,6 @@ if __name__ == "__main__":
                 lines.append("# imports end\n")
                 out_lines.extend([indentation + l for l in lines])
             elif line.strip().startswith("# gamewrapper"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# gamewrapper")
 
@@ -126,7 +130,6 @@ if __name__ == "__main__":
 
             # Find place to inject
             if line.strip().startswith("# plugin_cdef"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# plugin_cdef")
 
@@ -143,7 +146,6 @@ if __name__ == "__main__":
                 lines.append("# plugin_cdef end\n")
                 out_lines.extend([indentation + l for l in lines])
             elif line.strip().startswith("# imports"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# imports")
 
@@ -171,7 +173,6 @@ if __name__ == "__main__":
 
             # Find place to inject
             if line.strip().startswith("# docs exclude"):
-
                 lines = [line.strip() + "\n"]
                 indentation = " " * line.index("# docs exclude")
 
@@ -179,7 +180,7 @@ if __name__ == "__main__":
 
                 for p in (set(all_plugins) - set(game_wrappers)) | set(["manager", "manager_gen"]):
                     p_name = to_snake_case(p)
-                    lines.append(f"\"{p_name}\": False,\n")
+                    lines.append(f'"{p_name}": False,\n')
 
                 lines.append("# docs exclude end\n")
                 out_lines.extend([indentation + l for l in lines])

--- a/pyboy/plugins/record_replay.py
+++ b/pyboy/plugins/record_replay.py
@@ -38,10 +38,13 @@ class RecordReplay(PyBoyPlugin):
     def handle_events(self, events):
         # Input recorder
         if len(events) != 0:
-            self.recorded_input.append((
-                self.pyboy.frame_count, [e.event for e in events],
-                base64.b64encode(np.ascontiguousarray(self.pyboy.screen.ndarray[:, :, :-1])).decode("utf8")
-            ))
+            self.recorded_input.append(
+                (
+                    self.pyboy.frame_count,
+                    [e.event for e in events],
+                    base64.b64encode(np.ascontiguousarray(self.pyboy.screen.ndarray[:, :, :-1])).decode("utf8"),
+                )
+            )
         return events
 
     def stop(self):

--- a/pyboy/plugins/rewind.py
+++ b/pyboy/plugins/rewind.py
@@ -14,6 +14,7 @@ logger = pyboy.logging.get_logger(__name__)
 
 try:
     from cython import compiled
+
     cythonmode = compiled
 except ImportError:
     cythonmode = False
@@ -88,7 +89,7 @@ class Rewind(PyBoyPlugin):
 
 class FixedAllocBuffers(IntIOInterface):
     def __init__(self):
-        self.buffer = array.array("B", [0] * (FIXED_BUFFER_SIZE)) # NOQA: F821
+        self.buffer = array.array("B", [0] * (FIXED_BUFFER_SIZE))  # NOQA: F821
         for n in range(FIXED_BUFFER_SIZE):
             self.buffer[n] = FILL_VALUE
         self.sections = [0]
@@ -113,7 +114,7 @@ class FixedAllocBuffers(IntIOInterface):
         self.current_section += 1
         section_size = (self.section_head - self.section_tail + FIXED_BUFFER_SIZE) % FIXED_BUFFER_SIZE
         # Exponentially decaying moving average
-        self.avg_section_size = (0.9 * self.avg_section_size) + (0.1*section_size)
+        self.avg_section_size = (0.9 * self.avg_section_size) + (0.1 * section_size)
         self.section_tail = self.section_pointer
 
     def write(self, val):
@@ -138,7 +139,7 @@ class FixedAllocBuffers(IntIOInterface):
     def commit(self):
         if not self.section_head == self.section_pointer:
             raise Exception("Section wasn't read to finish. This would likely be unintentional")
-        self.sections = self.sections[:self.current_section + 1]
+        self.sections = self.sections[: self.current_section + 1]
 
     def seek_frame(self, frames):
         # TODO: Move for loop to Delta version
@@ -182,7 +183,7 @@ class CompressedFixedAllocBuffers(FixedAllocBuffers):
                 FixedAllocBuffers.write(self, 0)
                 FixedAllocBuffers.write(self, 0xFF)
 
-            if (rest != 0):
+            if rest != 0:
                 FixedAllocBuffers.write(self, 0)
                 FixedAllocBuffers.write(self, rest)
 
@@ -224,6 +225,7 @@ class DeltaFixedAllocBuffers(CompressedFixedAllocBuffers):
     I chose to keep the code simple at the expense of some edge cases acting different from the other buffers.
     When seeking, the last frame will be lost. This has no practical effect, and is only noticeble in unittesting.
     """
+
     def __init__(self):
         CompressedFixedAllocBuffers.__init__(self)
         self.internal_pointer = 0

--- a/pyboy/plugins/screen_recorder.py
+++ b/pyboy/plugins/screen_recorder.py
@@ -65,7 +65,7 @@ class ScreenRecorder(PyBoyPlugin):
                 loop=0,
                 optimize=True,
                 append_images=self.frames[1:],
-                duration=int(round(1000 / fps, -1))
+                duration=int(round(1000 / fps, -1)),
             )
 
             logger.info("Screen recording saved in {}".format(path))
@@ -75,6 +75,6 @@ class ScreenRecorder(PyBoyPlugin):
 
     def enabled(self):
         if Image is None:
-            logger.warning("%s: Missing dependency \"Pillow\". Recording disabled", __name__)
+            logger.warning('%s: Missing dependency "Pillow". Recording disabled', __name__)
             return False
         return True

--- a/pyboy/plugins/screenshot_recorder.py
+++ b/pyboy/plugins/screenshot_recorder.py
@@ -30,7 +30,6 @@ class ScreenshotRecorder(PyBoyPlugin):
         return events
 
     def save(self, path=None):
-
         if path is None:
             directory = os.path.join(os.path.curdir, "screenshots")
             if not os.path.exists(directory):
@@ -43,6 +42,6 @@ class ScreenshotRecorder(PyBoyPlugin):
 
     def enabled(self):
         if Image is None:
-            logger.warning("%s: Missing dependency \"Pillow\". Screenshots disabled", __name__)
+            logger.warning('%s: Missing dependency "Pillow". Screenshots disabled', __name__)
             return False
         return True

--- a/pyboy/plugins/window_open_gl.py
+++ b/pyboy/plugins/window_open_gl.py
@@ -16,12 +16,38 @@ logger = pyboy.logging.get_logger(__name__)
 
 try:
     import OpenGL.GLUT.freeglut
-    from OpenGL.GL import (GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, glClear,
-                           glDrawPixels, glFlush, glPixelZoom)
-    from OpenGL.GLUT import (GLUT_KEY_DOWN, GLUT_KEY_LEFT, GLUT_KEY_RIGHT, GLUT_KEY_UP, GLUT_RGBA, GLUT_SINGLE,
-                             glutCreateWindow, glutDestroyWindow, glutDisplayFunc, glutGetWindow, glutInit,
-                             glutInitDisplayMode, glutInitWindowSize, glutKeyboardFunc, glutKeyboardUpFunc,
-                             glutReshapeFunc, glutSetWindowTitle, glutSpecialFunc, glutSpecialUpFunc)
+    from OpenGL.GL import (
+        GL_COLOR_BUFFER_BIT,
+        GL_DEPTH_BUFFER_BIT,
+        GL_RGBA,
+        GL_UNSIGNED_INT_8_8_8_8_REV,
+        glClear,
+        glDrawPixels,
+        glFlush,
+        glPixelZoom,
+    )
+    from OpenGL.GLUT import (
+        GLUT_KEY_DOWN,
+        GLUT_KEY_LEFT,
+        GLUT_KEY_RIGHT,
+        GLUT_KEY_UP,
+        GLUT_RGBA,
+        GLUT_SINGLE,
+        glutCreateWindow,
+        glutDestroyWindow,
+        glutDisplayFunc,
+        glutGetWindow,
+        glutInit,
+        glutInitDisplayMode,
+        glutInitWindowSize,
+        glutKeyboardFunc,
+        glutKeyboardUpFunc,
+        glutReshapeFunc,
+        glutSetWindowTitle,
+        glutSpecialFunc,
+        glutSpecialUpFunc,
+    )
+
     opengl_enabled = True
 except (ImportError, AttributeError):
     opengl_enabled = False
@@ -50,7 +76,6 @@ class WindowOpenGL(PyBoyWindowPlugin):
         glPixelZoom(self.scale, self.scale)
         glutReshapeFunc(self._glreshape)
         glutDisplayFunc(self._gldraw)
-        
 
     # Cython does not cooperate with lambdas
     def _key(self, c, x, y):
@@ -145,9 +170,9 @@ class WindowOpenGL(PyBoyWindowPlugin):
                 if bool(OpenGL.GLUT.freeglut.glutMainLoopEvent):
                     return True
                 else:
-                    logger.error("Failed to load \"PyOpenGL\". OpenGL window disabled")
+                    logger.error('Failed to load "PyOpenGL". OpenGL window disabled')
             else:
-                logger.error("Missing depencency \"PyOpenGL\". OpenGL window disabled")
+                logger.error('Missing depencency "PyOpenGL". OpenGL window disabled')
         return False
 
     def post_tick(self):
@@ -156,5 +181,5 @@ class WindowOpenGL(PyBoyWindowPlugin):
 
     def stop(self):
         glutDestroyWindow(glutGetWindow())
-        for _ in range(10): # At least 2 to close
+        for _ in range(10):  # At least 2 to close
             OpenGL.GLUT.freeglut.glutMainLoopEvent()

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -22,7 +22,7 @@ logger = pyboy.logging.get_logger(__name__)
 ROWS, COLS = 144, 160
 
 # https://wiki.libsdl.org/SDL_Scancode#Related_Enumerations
-# yapf: disable
+# fmt: off
 if sdl2:
     KEY_DOWN = {
         sdl2.SDLK_UP        : WindowEvent.PRESS_ARROW_UP,
@@ -95,7 +95,7 @@ else:
     KEY_UP = {}
     CONTROLLER_DOWN = {}
     CONTROLLER_UP = {}
-# yapf: enable
+# fmt: on
 
 
 def sdl2_event_pump(events):

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -120,7 +120,7 @@ def sdl2_event_pump(events):
                     WindowEvent._INTERNAL_MOUSE,
                     window_id=event.motion.windowID,
                     mouse_scroll_x=event.wheel.x,
-                    mouse_scroll_y=event.wheel.y
+                    mouse_scroll_y=event.wheel.y,
                 )
             )
         elif event.type == sdl2.SDL_MOUSEMOTION or event.type == sdl2.SDL_MOUSEBUTTONUP:
@@ -137,7 +137,7 @@ def sdl2_event_pump(events):
                     window_id=event.motion.windowID,
                     mouse_x=event.motion.x,
                     mouse_y=event.motion.y,
-                    mouse_button=mouse_button
+                    mouse_button=mouse_button,
                 )
             )
         elif event.type == sdl2.SDL_CONTROLLERDEVICEADDED:
@@ -160,8 +160,12 @@ class WindowSDL2(PyBoyWindowPlugin):
         sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO | sdl2.SDL_INIT_GAMECONTROLLER)
 
         self._window = sdl2.SDL_CreateWindow(
-            b"PyBoy", sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED, self._scaledresolution[0],
-            self._scaledresolution[1], sdl2.SDL_WINDOW_RESIZABLE
+            b"PyBoy",
+            sdl2.SDL_WINDOWPOS_CENTERED,
+            sdl2.SDL_WINDOWPOS_CENTERED,
+            self._scaledresolution[0],
+            self._scaledresolution[1],
+            sdl2.SDL_WINDOW_RESIZABLE,
         )
 
         self._sdlrenderer = sdl2.SDL_CreateRenderer(self._window, -1, sdl2.SDL_RENDERER_ACCELERATED)
@@ -197,7 +201,7 @@ class WindowSDL2(PyBoyWindowPlugin):
         if self.pyboy_argv.get("window") in ("SDL2", None):
             if not sdl2:
                 logger.error("Failed to import sdl2, needed for sdl2 window")
-                return False # Disable, or raise exception?
+                return False  # Disable, or raise exception?
             else:
                 return True
         else:
@@ -205,6 +209,6 @@ class WindowSDL2(PyBoyWindowPlugin):
 
     def stop(self):
         sdl2.SDL_DestroyWindow(self._window)
-        for _ in range(10): # At least 2 to close
+        for _ in range(10):  # At least 2 to close
             get_events()
         sdl2.SDL_Quit()

--- a/pyboy/pyboy.py
+++ b/pyboy/pyboy.py
@@ -27,12 +27,15 @@ from .core.mb import Motherboard
 
 logger = get_logger(__name__)
 
-SPF = 1 / 60. # inverse FPS (frame-per-second)
+SPF = 1 / 60.0  # inverse FPS (frame-per-second)
 
 defaults = {
     "color_palette": (0xFFFFFF, 0x999999, 0x555555, 0x000000),
-    "cgb_color_palette": ((0xFFFFFF, 0x7BFF31, 0x0063C5, 0x000000), (0xFFFFFF, 0xFF8484, 0x943A3A, 0x000000),
-                          (0xFFFFFF, 0xFF8484, 0x943A3A, 0x000000)),
+    "cgb_color_palette": (
+        (0xFFFFFF, 0x7BFF31, 0x0063C5, 0x000000),
+        (0xFFFFFF, 0xFF8484, 0x943A3A, 0x000000),
+        (0xFFFFFF, 0xFF8484, 0x943A3A, 0x000000),
+    ),
     "scale": 3,
     "window": "SDL2",
     "log_level": "ERROR",
@@ -53,7 +56,7 @@ class PyBoy:
         cgb=None,
         gameshark=None,
         log_level=defaults["log_level"],
-        **kwargs
+        **kwargs,
     ):
         """
         PyBoy is loadable as an object in Python. This means, it can be initialized from another script, and be
@@ -113,7 +116,7 @@ class PyBoy:
 
         kwargs["window"] = window
         kwargs["scale"] = scale
-        randomize = kwargs.pop("randomize", False) # Undocumented feature
+        randomize = kwargs.pop("randomize", False)  # Undocumented feature
 
         for k, v in defaults.items():
             if k not in kwargs:
@@ -457,7 +460,7 @@ class PyBoy:
         running = False
         t_start = time.perf_counter_ns()
         while count != 0:
-            _render = render and count == 1 # Only render on last tick to improve performance
+            _render = render and count == 1  # Only render on last tick to improve performance
             running = self._tick(_render)
             count -= 1
         t_tick = time.perf_counter_ns()
@@ -466,9 +469,9 @@ class PyBoy:
 
         if _count > 0:
             nsecs = t_tick - t_start
-            self.avg_tick = 0.9 * (self.avg_tick / _count) + (0.1*nsecs/1_000_000_000)
+            self.avg_tick = 0.9 * (self.avg_tick / _count) + (0.1 * nsecs / 1_000_000_000)
             nsecs = t_post - t_start
-            self.avg_emu = 0.9 * (self.avg_emu / _count) + (0.1*nsecs/1_000_000_000)
+            self.avg_emu = 0.9 * (self.avg_emu / _count) + (0.1 * nsecs / 1_000_000_000)
         return running
 
     def _handle_events(self, events):
@@ -492,7 +495,7 @@ class PyBoy:
                 with open(state_path, "rb") as f:
                     self.mb.load_state(IntIOWrapper(f))
             elif event == WindowEvent.PASS:
-                pass # Used in place of None in Cython, when key isn't mapped to anything
+                pass  # Used in place of None in Cython, when key isn't mapped to anything
             elif event == WindowEvent.PAUSE_TOGGLE:
                 if self.paused:
                     self._unpause()
@@ -1329,6 +1332,7 @@ class PyBoyRegisterFile:
     True
     ```
     """
+
     def __init__(self, cpu):
         self.cpu = cpu
 
@@ -1506,6 +1510,7 @@ class PyBoyMemoryView:
     ```
 
     """
+
     def __init__(self, mb):
         self.mb = mb
 
@@ -1541,7 +1546,7 @@ class PyBoyMemoryView:
             return self.__getitem(addr, 0, 1, bank, is_single, is_bank)
 
     def __getitem(self, start, stop, step, bank, is_single, is_bank):
-        slice_length = (stop-start) // step
+        slice_length = (stop - start) // step
         if is_bank:
             # Reading a specific bank
             if start < 0x8000:
@@ -1556,7 +1561,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         mem_slice = [0] * slice_length
                         for x in range(start, stop, step):
-                            mem_slice[(x-start) // step] = self.mb.bootrom.bootrom[x]
+                            mem_slice[(x - start) // step] = self.mb.bootrom.bootrom[x]
                         return mem_slice
                     else:
                         return self.mb.bootrom.bootrom[start]
@@ -1565,7 +1570,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         mem_slice = [0] * slice_length
                         for x in range(start, stop, step):
-                            mem_slice[(x-start) // step] = self.mb.cartridge.rombanks[bank, x]
+                            mem_slice[(x - start) // step] = self.mb.cartridge.rombanks[bank, x]
                         return mem_slice
                     else:
                         return self.mb.cartridge.rombanks[bank, start]
@@ -1581,7 +1586,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         mem_slice = [0] * slice_length
                         for x in range(start, stop, step):
-                            mem_slice[(x-start) // step] = self.mb.lcd.VRAM0[x]
+                            mem_slice[(x - start) // step] = self.mb.lcd.VRAM0[x]
                         return mem_slice
                     else:
                         return self.mb.lcd.VRAM0[start]
@@ -1589,7 +1594,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         mem_slice = [0] * slice_length
                         for x in range(start, stop, step):
-                            mem_slice[(x-start) // step] = self.mb.lcd.VRAM1[x]
+                            mem_slice[(x - start) // step] = self.mb.lcd.VRAM1[x]
                         return mem_slice
                     else:
                         return self.mb.lcd.VRAM1[start]
@@ -1602,7 +1607,7 @@ class PyBoyMemoryView:
                 if not is_single:
                     mem_slice = [0] * slice_length
                     for x in range(start, stop, step):
-                        mem_slice[(x-start) // step] = self.mb.cartridge.rambanks[bank, x]
+                        mem_slice[(x - start) // step] = self.mb.cartridge.rambanks[bank, x]
                     return mem_slice
                 else:
                     return self.mb.cartridge.rambanks[bank, start]
@@ -1619,17 +1624,17 @@ class PyBoyMemoryView:
                 if not is_single:
                     mem_slice = [0] * slice_length
                     for x in range(start, stop, step):
-                        mem_slice[(x-start) // step] = self.mb.ram.internal_ram0[x + bank*0x1000]
+                        mem_slice[(x - start) // step] = self.mb.ram.internal_ram0[x + bank * 0x1000]
                     return mem_slice
                 else:
-                    return self.mb.ram.internal_ram0[start + bank*0x1000]
+                    return self.mb.ram.internal_ram0[start + bank * 0x1000]
             else:
                 assert None, "Invalid memory address for bank"
         elif not is_single:
             # Reading slice of memory space
             mem_slice = [0] * slice_length
             for x in range(start, stop, step):
-                mem_slice[(x-start) // step] = self.mb.getitem(x)
+                mem_slice[(x - start) // step] = self.mb.getitem(x)
             return mem_slice
         else:
             # Reading specific address of memory space
@@ -1682,7 +1687,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         # Writing slice of memory space
                         if hasattr(v, "__iter__"):
-                            assert (stop-start) // step == len(v), "slice does not match length of data"
+                            assert (stop - start) // step == len(v), "slice does not match length of data"
                             _v = iter(v)
                             for x in range(start, stop, step):
                                 self.mb.bootrom.bootrom[x] = next(_v)
@@ -1695,7 +1700,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         # Writing slice of memory space
                         if hasattr(v, "__iter__"):
-                            assert (stop-start) // step == len(v), "slice does not match length of data"
+                            assert (stop - start) // step == len(v), "slice does not match length of data"
                             _v = iter(v)
                             for x in range(start, stop, step):
                                 self.mb.cartridge.overrideitem(bank, x, next(_v))
@@ -1717,7 +1722,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         # Writing slice of memory space
                         if hasattr(v, "__iter__"):
-                            assert (stop-start) // step == len(v), "slice does not match length of data"
+                            assert (stop - start) // step == len(v), "slice does not match length of data"
                             _v = iter(v)
                             for x in range(start, stop, step):
                                 self.mb.lcd.VRAM0[x] = next(_v)
@@ -1730,7 +1735,7 @@ class PyBoyMemoryView:
                     if not is_single:
                         # Writing slice of memory space
                         if hasattr(v, "__iter__"):
-                            assert (stop-start) // step == len(v), "slice does not match length of data"
+                            assert (stop - start) // step == len(v), "slice does not match length of data"
                             _v = iter(v)
                             for x in range(start, stop, step):
                                 self.mb.lcd.VRAM1[x] = next(_v)
@@ -1748,7 +1753,7 @@ class PyBoyMemoryView:
                 if not is_single:
                     # Writing slice of memory space
                     if hasattr(v, "__iter__"):
-                        assert (stop-start) // step == len(v), "slice does not match length of data"
+                        assert (stop - start) // step == len(v), "slice does not match length of data"
                         _v = iter(v)
                         for x in range(start, stop, step):
                             self.mb.cartridge.rambanks[bank, x] = next(_v)
@@ -1770,21 +1775,21 @@ class PyBoyMemoryView:
                 if not is_single:
                     # Writing slice of memory space
                     if hasattr(v, "__iter__"):
-                        assert (stop-start) // step == len(v), "slice does not match length of data"
+                        assert (stop - start) // step == len(v), "slice does not match length of data"
                         _v = iter(v)
                         for x in range(start, stop, step):
-                            self.mb.ram.internal_ram0[x + bank*0x1000] = next(_v)
+                            self.mb.ram.internal_ram0[x + bank * 0x1000] = next(_v)
                     else:
                         for x in range(start, stop, step):
-                            self.mb.ram.internal_ram0[x + bank*0x1000] = v
+                            self.mb.ram.internal_ram0[x + bank * 0x1000] = v
                 else:
-                    self.mb.ram.internal_ram0[start + bank*0x1000] = v
+                    self.mb.ram.internal_ram0[start + bank * 0x1000] = v
             else:
                 assert None, "Invalid memory address for bank"
         elif not is_single:
             # Writing slice of memory space
             if hasattr(v, "__iter__"):
-                assert (stop-start) // step == len(v), "slice does not match length of data"
+                assert (stop - start) // step == len(v), "slice does not match length of data"
                 _v = iter(v)
                 for x in range(start, stop, step):
                     self.mb.setitem(x, next(_v))

--- a/pyboy/utils.py
+++ b/pyboy/utils.py
@@ -88,6 +88,7 @@ class IntIOWrapper(IntIOInterface):
     Wraps a file-like object to allow writing integers to it.
     This allows for higher performance, when writing to a memory map in rewind.
     """
+
     def __init__(self, buf):
         self.buffer = buf
 
@@ -300,7 +301,7 @@ def dec_to_bcd(value, byte_width=1, byteorder="little"):
     """
     bcd_result = []
     for _ in range(byte_width):
-        tens = ((value%100) // 10) << 4
+        tens = ((value % 100) // 10) << 4
         units = value % 10
         bcd_byte = (tens | units) & 0xFF
         bcd_result.append(bcd_byte)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,22 +63,14 @@ packages = ["pyboy", "pyboy.api", "pyboy.core", "pyboy.core.cartridge", "pyboy.l
     "**/font.txt"
 ]
 
-[tool.isort]
-line_length = 120
+[tool.ruff]
+line-length = 120
 
-[tool.yapf]
-based_on_style = "facebook"
-spaces_before_comment = 1
-column_limit = 120
-align_closing_bracket_with_visual_indent = false
-dedent_closing_brackets = true
-coalesce_brackets = true
-indent_closing_brackets = false
-indent_dictionary_value = true
-join_multiple_lines = false
-split_penalty_after_opening_bracket = 0
-split_penalty_before_if_expr = 30
-split_penalty_for_added_line_split = 30
-split_before_logical_operator = false
-split_before_bitwise_operator = false
-arithmetic_precedence_indication = true
+[tool.ruff.format]
+quote-style = "double"
+docstring-code-format = false
+
+[tool.ruff.lint]
+# select = ["E", "F"]
+# select = ["E4", "E7", "E9", "F"]
+ignore = ["E741", "E731", "E712"]

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,12 @@ def patched_error(position, message):
         # We ignore this error to pass PyObject* to logging
         return
     else:
-        #print("Errors.error:", repr(position), repr(message)) ###
+        # print("Errors.error:", repr(position), repr(message)) ###
         if position is None:
             raise Errors.InternalError(message)
         err = Errors.CompileError(position, message)
         if DebugFlags.debug_exception_on_error:
-            raise Exception(err) # debug
+            raise Exception(err)  # debug
         Errors.report_error(err)
         return err
 
@@ -43,13 +43,16 @@ class build_ext(_build_ext):
         self.parallel = cpu_count()
 
         if sys.platform == "win32":
-            thread_count = 0 # Disables multiprocessing
+            thread_count = 0  # Disables multiprocessing
         else:
             thread_count = cpu_count()
 
         # Fixing issue with nthreads in Cython
-        if (3,
-            8) <= sys.version_info[:2] and sys.platform == "darwin" and multiprocessing.get_start_method() == "spawn":
+        if (
+            (3, 8) <= sys.version_info[:2]
+            and sys.platform == "darwin"
+            and multiprocessing.get_start_method() == "spawn"
+        ):
             multiprocessing.set_start_method("fork", force=True)
 
         cflags = ["-O3"]
@@ -65,7 +68,8 @@ class build_ext(_build_ext):
                 extra_compile_args=cflags,
                 extra_link_args=["-s", "-w"],
                 include_dirs=[np.get_include()],
-            ), list(py_pxd_files)
+            ),
+            list(py_pxd_files),
         )
         self.distribution.ext_modules = cythonize(
             [*cythonize_files],
@@ -107,5 +111,5 @@ setup(
     cmdclass={
         "build_ext": build_ext,
     },
-    ext_modules=[Extension("", [""])], # Added to trigger a binary wheel
+    ext_modules=[Extension("", [""])],  # Added to trigger a binary wheel
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def locate_roms(path=default_rom_path):
         lambda x: path + x,
         filter(
             lambda x: x.lower().endswith(".gb") or x.lower().endswith(".gbc") or x.endswith(".bin"), os.listdir(path)
-        )
+        ),
     )
 
     entries = {}
@@ -106,6 +106,7 @@ def pokemon_gold_rom(secrets):
 @pytest.fixture(scope="session")
 def pokemon_crystal_rom(secrets):
     return locate_sha256(b"d6702e353dcbe2d2c69183046c878ef13a0dae4006e8cdff521cca83dd1582fe")
+
 
 @pytest.fixture(scope="session")
 def pokemon_pinball_rom(secrets):
@@ -281,6 +282,7 @@ def git_tetris_ai():
         return None
 
     import venv
+
     path = Path("tetris")
     with FileLock(path.with_suffix(".lock")) as lock:
         if not os.path.isdir(path):
@@ -291,9 +293,12 @@ def git_tetris_ai():
         _venv_path = Path(".venv")
         _venv.create(path / _venv_path)
         # _venv_context = _venv.ensure_directories(path / Path('.venv'))
-        assert os.system(
-            f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install numpy torch matplotlib graphviz'
-        ) == 0
+        assert (
+            os.system(
+                f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install numpy torch matplotlib graphviz'
+            )
+            == 0
+        )
         # Overwrite PyBoy with local version
         assert os.system(f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install ../') == 0
     return str(path)
@@ -305,6 +310,7 @@ def git_pyboy_rl():
         return None
 
     import venv
+
     path = Path("PyBoy-RL")
     with FileLock(path.with_suffix(".lock")) as lock:
         if not os.path.isdir(path):
@@ -327,6 +333,7 @@ def git_pokemon_red_experiments():
         return None
 
     import venv
+
     path = Path("PokemonRedExperiments")
     with FileLock(path.with_suffix(".lock")) as lock:
         if not os.path.isdir(path):
@@ -337,9 +344,10 @@ def git_pokemon_red_experiments():
         _venv_path = Path(".venv")
         _venv.create(path / _venv_path)
         # _venv_context = _venv.ensure_directories(path / Path('.venv'))
-        assert os.system(
-            f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install -r baselines/requirements.txt'
-        ) == 0
+        assert (
+            os.system(f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install -r baselines/requirements.txt')
+            == 0
+        )
         # Overwrite PyBoy with local version
         assert os.system(f'cd {path} && . {_venv_path / "bin" / "activate"} && pip install ../') == 0
     return str(path)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -60,13 +60,13 @@ def test_register_file(default_rom):
     pyboy.register_file.A = 0x1AB
     assert pyboy.register_file.A == 0xAB
     pyboy.register_file.F = 0xFF
-    assert pyboy.register_file.F == 0xF0 # Lower 4 bits always zero on F
+    assert pyboy.register_file.F == 0xF0  # Lower 4 bits always zero on F
     pyboy.register_file.SP = 0x1234
     assert pyboy.register_file.SP == 0x1234
 
     def change_sp(p):
         assert p.register_file.SP == 0xFFFE, "Expected 0xFFFE from boot ROM"
-        p.register_file.SP = 0xFF00 # We should see this at the end too
+        p.register_file.SP = 0xFF00  # We should see this at the end too
 
     registers = [0] * 9
 
@@ -118,8 +118,9 @@ def test_record_replay(boot_rom, default_rom):
 
     os.remove(default_rom + ".replay")
 
-    assert digest == (b'r\x80\x19)\x1a\x88\r\xcc\xb9\xab\xa3\xda\xb1&i\xc8"\xc2\xfb\x8a\x01\x9b\xa81@\x92V=5\x92\\5'), \
-        "The replay did not result in the expected output"
+    assert digest == (
+        b'r\x80\x19)\x1a\x88\r\xcc\xb9\xab\xa3\xda\xb1&i\xc8"\xc2\xfb\x8a\x01\x9b\xa81@\x92V=5\x92\\5'
+    ), "The replay did not result in the expected output"
 
 
 def test_argv_parser(*args):
@@ -143,16 +144,16 @@ def test_argv_parser(*args):
         "record_input": False,
         "rewind": False,
         "scale": 3,
-        "window": "SDL2"
+        "window": "SDL2",
     }.items():
         assert empty[k] == v
 
     # Check the assumed behavior of loadstate with and without argument
     assert parser.parse_args(file_that_exists.split(" ")).loadstate is None
     assert parser.parse_args(f"{file_that_exists} --loadstate".split(" ")).loadstate == main.INTERNAL_LOADSTATE
-    assert parser.parse_args(
-        f"{file_that_exists} --loadstate {file_that_exists}".split(" ")
-    ).loadstate == file_that_exists
+    assert (
+        parser.parse_args(f"{file_that_exists} --loadstate {file_that_exists}".split(" ")).loadstate == file_that_exists
+    )
 
     # Check flags become True
     flags = parser.parse_args(
@@ -188,7 +189,7 @@ def test_tilemaps(kirby_rom):
         [256, 259, 275, 291, 307, 323, 339, 355, 371, 271, 287, 303, 319, 335, 351, 367, 383, 256, 256, 256],
         [256, 256, 276, 292, 308, 324, 340, 356, 372, 272, 320, 260, 261, 262, 361, 182, 346, 256, 256, 256],
         [256, 256, 277, 293, 309, 325, 341, 357, 373, 128, 181, 362, 378, 299, 315, 331, 256, 256, 256, 256],
-        [256, 256, 278, 294, 310, 326, 342, 358, 374, 129, 164, 132, 136, 140, 143, 146, 150, 167, 157, 168]
+        [256, 256, 278, 294, 310, 326, 342, 358, 374, 129, 164, 132, 136, 140, 143, 146, 150, 167, 157, 168],
     ]
     assert isinstance(bck_tilemap.tile(0, 0), Tile)
     assert bck_tilemap.tile_identifier(0, 0) == 256
@@ -209,7 +210,7 @@ def test_tilemaps(kirby_rom):
         [256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256],
         [256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256],
         [256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256],
-        [256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256]
+        [256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256],
     ]
     assert isinstance(wdw_tilemap.tile(0, 0), Tile)
     assert wdw_tilemap.tile_identifier(0, 0) == 256
@@ -249,8 +250,22 @@ def test_not_cgb(pokemon_crystal_rom):
     pyboy.tick(60 * 7, False)
 
     assert pyboy.tilemap_background[1:16, 16] == [
-        134, 160, 172, 164, 383, 129, 174, 184, 383, 130, 174, 171, 174, 177, 232
-    ] # Assert that the screen says "Game Boy Color." at the bottom.
+        134,
+        160,
+        172,
+        164,
+        383,
+        129,
+        174,
+        184,
+        383,
+        130,
+        174,
+        171,
+        174,
+        177,
+        232,
+    ]  # Assert that the screen says "Game Boy Color." at the bottom.
 
     pyboy.stop(save=False)
 

--- a/tests/test_blargg.py
+++ b/tests/test_blargg.py
@@ -36,7 +36,7 @@ def run_rom(rom, max_frames):
 
     pyboy.tick(10, False)
     pyboy.stop(save=False)
-    result += pyboy._serial() # Getting the absolute last. Some times the tests says "Failed X tests".
+    result += pyboy._serial()  # Getting the absolute last. Some times the tests says "Failed X tests".
     if result == "":
         n = 0
         while True:
@@ -51,7 +51,8 @@ def run_rom(rom, max_frames):
 
 
 @pytest.mark.parametrize(
-    "test_rom, max_frames", [
+    "test_rom, max_frames",
+    [
         ("cgb_sound/cgb_sound.gb", 4_000),
         ("cgb_sound/rom_singles/01-registers.gb", 700),
         ("cgb_sound/rom_singles/02-len ctr.gb", 700),
@@ -109,7 +110,7 @@ def run_rom(rom, max_frames):
         ("oam_bug/rom_singles/6-timing_no_bug.gb", 700),
         ("oam_bug/rom_singles/7-timing_effect.gb", 700),
         ("oam_bug/rom_singles/8-instr_effect.gb", 700),
-    ]
+    ],
 )
 def test_blarggs(test_rom, max_frames, blargg_dir):
     rom = str(blargg_dir / Path(test_rom))
@@ -121,7 +122,7 @@ def test_blarggs(test_rom, max_frames, blargg_dir):
     else:
         old_blargg = None
 
-    rom = rom.replace("\\", "/") # Fix Windows lookup
+    rom = rom.replace("\\", "/")  # Fix Windows lookup
     rom = rom.replace("test_roms/", "")
     if OVERWRITE_JSON:
         with open(blargg_json, "w") as f:

--- a/tests/test_breakpoints.py
+++ b/tests/test_breakpoints.py
@@ -66,8 +66,8 @@ def test_register_hook_context(default_rom):
 
     _context = []
 
-    bank = -1 # "ROM bank number" for bootrom
-    addr = 0xFC # Address of last instruction. Expected to execute once.
+    bank = -1  # "ROM bank number" for bootrom
+    addr = 0xFC  # Address of last instruction. Expected to execute once.
     pyboy.hook_register(bank, addr, _inner_callback, _context)
     for _ in range(120):
         pyboy.tick()
@@ -82,8 +82,8 @@ def test_register_hook_print(default_rom, capfd):
     def _inner_callback(context):
         print(context)
 
-    bank = -1 # "ROM bank number" for bootrom
-    addr = 0xFC # Address of last instruction. Expected to execute once.
+    bank = -1  # "ROM bank number" for bootrom
+    addr = 0xFC  # Address of last instruction. Expected to execute once.
     pyboy.hook_register(bank, addr, _inner_callback, "Hello!")
     for _ in range(120):
         pyboy.tick()
@@ -159,8 +159,8 @@ def test_register_hook_label(default_rom):
 
     _context = []
 
-    bank = None # Use None to look up symbol
-    symbol = "Main.move" # Address of last instruction. Expected to execute once.
+    bank = None  # Use None to look up symbol
+    symbol = "Main.move"  # Address of last instruction. Expected to execute once.
     pyboy.hook_register(bank, symbol, _inner_callback, _context)
     for _ in range(120):
         pyboy.tick()
@@ -177,8 +177,8 @@ def test_register_hook_context2(default_rom):
 
     _context = []
 
-    bank = -1 # "ROM bank number" for bootrom
-    addr = 0x06 # Erase routine, expected 8192 times
+    bank = -1  # "ROM bank number" for bootrom
+    addr = 0x06  # Erase routine, expected 8192 times
     pyboy.hook_register(bank, addr, _inner_callback, _context)
 
     for _ in range(120):
@@ -248,7 +248,7 @@ def test_data_hooking_failure(default_rom):
     # NOTE: We are not supposed to register hooks for data
     pyboy2.hook_register(None, "Tilemap", mock.method1, None)
     pyboy2.tick(ticks, True)
-    mock.method1.assert_not_called() # Shouldn't be called, as it's not a function
+    mock.method1.assert_not_called()  # Shouldn't be called, as it's not a function
 
     # Compare screens
     image1 = pyboy1.screen.image.convert("RGB")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,11 +13,12 @@ from pytest_lazy_fixtures import lf
 
 
 @pytest.mark.parametrize(
-    "gamewrapper, rom", [
+    "gamewrapper, rom",
+    [
         ("gamewrapper_tetris.py", lf("tetris_rom")),
         ("gamewrapper_mario.py", lf("supermarioland_rom")),
         ("gamewrapper_kirby.py", lf("kirby_rom")),
-    ]
+    ],
 )
 def test_record_replay(gamewrapper, rom):
     script_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -39,7 +39,7 @@ def test_rtc_lock(pokemon_gold_rom):
     pyboy = PyBoy(pokemon_gold_rom, window="null")
     pyboy.rtc_lock_experimental(False)
 
-    #Enable external RAM
+    # Enable external RAM
     pyboy.memory[0x0000] = 0x0A
 
     # Reset seconds
@@ -51,18 +51,18 @@ def test_rtc_lock(pokemon_gold_rom):
     pyboy.memory[0xA000] = 0
 
     # Reset hours
-    pyboy.memory[0x4000] = 0x0a
+    pyboy.memory[0x4000] = 0x0A
     pyboy.memory[0xA000] = 0
 
     # Reset days (low)
-    pyboy.memory[0x4000] = 0x0b
+    pyboy.memory[0x4000] = 0x0B
     pyboy.memory[0xA000] = 0
 
     # Reset days (high)
-    pyboy.memory[0x4000] = 0x0c
+    pyboy.memory[0x4000] = 0x0C
     pyboy.memory[0xA000] = 0
 
-    time.sleep(2) # Induce a change in the seconds register
+    time.sleep(2)  # Induce a change in the seconds register
 
     # Pan docs:
     # When writing $00, and then $01 to this register, the current time becomes latched into the RTC registers
@@ -77,13 +77,13 @@ def test_rtc_lock(pokemon_gold_rom):
     pyboy.memory[0x4000] = 0x09
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0a
+    pyboy.memory[0x4000] = 0x0A
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0b
+    pyboy.memory[0x4000] = 0x0B
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0c
+    pyboy.memory[0x4000] = 0x0C
     assert pyboy.memory[0xA000] == 0
 
     pyboy.rtc_lock_experimental(True)
@@ -101,13 +101,13 @@ def test_rtc_lock(pokemon_gold_rom):
     pyboy.memory[0x4000] = 0x09
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0a
+    pyboy.memory[0x4000] = 0x0A
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0b
+    pyboy.memory[0x4000] = 0x0B
     assert pyboy.memory[0xA000] == 0
 
-    pyboy.memory[0x4000] = 0x0c
+    pyboy.memory[0x4000] = 0x0C
     assert pyboy.memory[0xA000] == 0
 
 
@@ -143,7 +143,7 @@ def test_tiles(default_rom):
     assert isinstance(tile, Tile)
 
     with pytest.raises(AssertionError):
-        pyboy.get_tile(384) # Not CGB
+        pyboy.get_tile(384)  # Not CGB
     tile = pyboy.get_tile(1)
     image = tile.image()
     assert isinstance(image, PIL.Image.Image)
@@ -154,15 +154,16 @@ def test_tiles(default_rom):
     # data = tile.image_data()
     # assert data.shape == (8, 8)
 
-    assert [[x & 0xFFFFFF for x in y] for y in ndarray.view(dtype=np.uint32).reshape(8, 8)
-           ] == [[0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                 [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                 [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                 [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF],
-                 [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF],
-                 [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
-                 [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
-                 [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF]]
+    assert [[x & 0xFFFFFF for x in y] for y in ndarray.view(dtype=np.uint32).reshape(8, 8)] == [
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+    ]
 
     for identifier in range(384):
         t = pyboy.get_tile(identifier)
@@ -193,15 +194,16 @@ def test_tiles_cgb(any_rom_cgb):
     # data = tile.image_data()
     # assert data.shape == (8, 8)
 
-    assert [[x for x in y]
-            for y in ndarray] == [[0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                                  [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                                  [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
-                                  [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF],
-                                  [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF],
-                                  [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
-                                  [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
-                                  [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF]]
+    assert [[x for x in y] for y in ndarray] == [
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+        [0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF, 0xFFFFFF, 0x000000, 0x000000, 0xFFFFFF],
+    ]
 
     for identifier in range(384):
         t = pyboy.get_tile(identifier)
@@ -219,7 +221,7 @@ def test_tiles_cgb(any_rom_cgb):
     pyboy.set_emulation_speed(0)
     pyboy.tick(BOOTROM_FRAMES_UNTIL_LOGO, False)
 
-    pyboy.get_tile(384) # Allowed on CGB
+    pyboy.get_tile(384)  # Allowed on CGB
 
 
 def test_screen_buffer_and_image(tetris_rom, boot_rom):
@@ -228,7 +230,7 @@ def test_screen_buffer_and_image(tetris_rom, boot_rom):
 
     pyboy = PyBoy(tetris_rom, window="null", bootrom=boot_rom)
     pyboy.set_emulation_speed(0)
-    pyboy.tick(275, True) # Iterate to boot logo
+    pyboy.tick(275, True)  # Iterate to boot logo
 
     assert pyboy.screen.raw_buffer_dims == (144, 160)
     assert pyboy.screen.raw_buffer_format == cformat
@@ -236,16 +238,15 @@ def test_screen_buffer_and_image(tetris_rom, boot_rom):
     boot_logo_hash = hashlib.sha256()
 
     if hasattr(pyboy.screen.raw_buffer, "tobytes"):
-        boot_logo_hash.update(pyboy.screen.raw_buffer.tobytes()) # PyPy
+        boot_logo_hash.update(pyboy.screen.raw_buffer.tobytes())  # PyPy
     else:
-        boot_logo_hash.update(pyboy.screen.raw_buffer.base) # Cython
+        boot_logo_hash.update(pyboy.screen.raw_buffer.base)  # Cython
     # assert boot_logo_hash.digest() == boot_logo_hash_predigested
     # assert isinstance(pyboy.screen.raw_buffer, bytes)
 
     # The output of `image` is supposed to be homogeneous, which means a shared hash between versions.
     boot_logo_png_hash_predigested = (
-        b"\x1b\xab\x90r^\xfb\x0e\xef\xf1\xdb\xf8\xba\xb6:^\x01"
-        b"\xa4\x0eR&\xda9\xfcg\xf7\x0f|\xba}\x08\xb6$"
+        b"\x1b\xab\x90r^\xfb\x0e\xef\xf1\xdb\xf8\xba\xb6:^\x01" b"\xa4\x0eR&\xda9\xfcg\xf7\x0f|\xba}\x08\xb6$"
     )
     boot_logo_png_hash = hashlib.sha256()
     image = pyboy.screen.image.convert("RGB")
@@ -307,7 +308,7 @@ def test_tetris(tetris_rom):
     first_brick = False
     tile_map = pyboy.tilemap_background
     state_data = io.BytesIO()
-    for frame in range(5282): # Enough frames to get a "Game Over". Otherwise do: `while pyboy.tick(False):`
+    for frame in range(5282):  # Enough frames to get a "Game Over". Otherwise do: `while pyboy.tick(False):`
         image = pyboy.tick(1, True)
 
         assert pyboy.screen.get_tilemap_position() == ((0, 0), (-7, 0))
@@ -350,24 +351,28 @@ def test_tetris(tetris_rom):
                     print("First brick touched the bottom!")
 
                     game_board_matrix = list(tile_map[2:12, :18])
-                    assert game_board_matrix == ([[47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 133, 133, 133],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 133, 47]])
+                    assert game_board_matrix == (
+                        [
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 133, 133, 133],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 133, 47],
+                        ]
+                    )
 
                     tile_map.use_tile_objects(True)
 
@@ -379,24 +384,28 @@ def test_tetris(tetris_rom):
 
                     game_board_matrix = [[x.tile_identifier for x in row] for row in tile_map[2:12, :18]]
                     tile_map.use_tile_objects(False)
-                    assert game_board_matrix == ([[47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                                  [47, 47, 47, 47, 47, 47, 47, 133, 133, 133],
-                                                  [47, 47, 47, 47, 47, 47, 47, 47, 133, 47]])
+                    assert game_board_matrix == (
+                        [
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                            [47, 47, 47, 47, 47, 47, 47, 133, 133, 133],
+                            [47, 47, 47, 47, 47, 47, 47, 47, 133, 47],
+                        ]
+                    )
 
             if frame == 1012:
                 assert not first_brick
@@ -411,56 +420,61 @@ def test_tetris(tetris_rom):
                 assert s1.tiles[0] == s2.tiles[0], "Testing equal tiles of two different sprites"
 
                 # Test that both ways of getting identifiers work and provides the same result.
-                all_sprites = [(s.x, s.y, s.tiles[0].tile_identifier, s.on_screen)
-                               for s in [pyboy.get_sprite(n) for n in range(40)]]
-                all_sprites2 = [(s.x, s.y, s.tile_identifier, s.on_screen)
-                                for s in [pyboy.get_sprite(n) for n in range(40)]]
+                all_sprites = [
+                    (s.x, s.y, s.tiles[0].tile_identifier, s.on_screen)
+                    for s in [pyboy.get_sprite(n) for n in range(40)]
+                ]
+                all_sprites2 = [
+                    (s.x, s.y, s.tile_identifier, s.on_screen) for s in [pyboy.get_sprite(n) for n in range(40)]
+                ]
                 assert all_sprites == all_sprites2
 
                 # Verify data with known reference
                 # pyboy.screen.image.show()
-                assert all_sprites == ([
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (72, 128, 133, True),
-                    (80, 128, 133, True),
-                    (88, 128, 133, True),
-                    (80, 136, 133, True),
-                    (120, 112, 133, True),
-                    (128, 112, 133, True),
-                    (136, 112, 133, True),
-                    (128, 120, 133, True),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                    (-8, -16, 0, False),
-                ])
+                assert all_sprites == (
+                    [
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (72, 128, 133, True),
+                        (80, 128, 133, True),
+                        (88, 128, 133, True),
+                        (80, 136, 133, True),
+                        (120, 112, 133, True),
+                        (128, 112, 133, True),
+                        (136, 112, 133, True),
+                        (128, 120, 133, True),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                        (-8, -16, 0, False),
+                    ]
+                )
 
                 assert pyboy.memory[NEXT_TETROMINO] == 24
                 assert tetris.next_tetromino() == "T"
@@ -479,30 +493,34 @@ def test_tetris(tetris_rom):
 
         if frame == 1864:
             game_board_matrix = list(tile_map[2:12, :18])
-            assert game_board_matrix == ([[47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
-                                          [47, 47, 47, 133, 133, 133, 47, 133, 133, 133],
-                                          [47, 47, 47, 47, 133, 47, 47, 47, 133, 47]])
+            assert game_board_matrix == (
+                [
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 47, 47, 47, 47, 47, 47, 47],
+                    [47, 47, 47, 133, 133, 133, 47, 133, 133, 133],
+                    [47, 47, 47, 47, 133, 47, 47, 47, 133, 47],
+                ]
+            )
             pre_load_game_board_matrix = game_board_matrix
 
-    state_data.seek(0) # Reset to the start of the buffer. Otherwise, we call `load_state` at end of file
+    state_data.seek(0)  # Reset to the start of the buffer. Otherwise, we call `load_state` at end of file
     tmp_state.seek(0)
-    for _f in [tmp_state, state_data]: # Tests both file-written state and in-memory state
-        pyboy.load_state(_f) # Reverts memory state to before we changed the Tetromino
+    for _f in [tmp_state, state_data]:  # Tests both file-written state and in-memory state
+        pyboy.load_state(_f)  # Reverts memory state to before we changed the Tetromino
         pyboy.tick(1, False)
         for frame in range(1016, 1865):
             pyboy.tick(1, False)
@@ -530,9 +548,9 @@ def test_tilemap_position_list(supermarioland_rom):
     # Get screen positions, and verify the values
     positions = pyboy.screen.tilemap_position_list
     for y in range(1, 16):
-        assert positions[y][0] == 0 # HUD
+        assert positions[y][0] == 0  # HUD
     for y in range(16, 144):
-        assert positions[y][0] >= 50 # Actual screen position
+        assert positions[y][0] >= 50  # Actual screen position
         last_y = positions[y][0]
 
     # Progress another 10 frames to see and increase in SCX
@@ -541,9 +559,9 @@ def test_tilemap_position_list(supermarioland_rom):
     # Get screen positions, and verify the values
     positions = pyboy.screen.tilemap_position_list
     for y in range(1, 16):
-        assert positions[y][0] == 0 # HUD
+        assert positions[y][0] == 0  # HUD
     for y in range(16, 144):
-        assert positions[y][0] >= last_y + 10 # Actual screen position
+        assert positions[y][0] >= last_y + 10  # Actual screen position
 
     pyboy.stop(save=False)
 
@@ -552,26 +570,26 @@ def test_button(default_rom):
     pyboy = PyBoy(default_rom, window="null")
     pyboy.set_emulation_speed(0)
 
-    assert len(pyboy.events) == 0 # Nothing injected yet
+    assert len(pyboy.events) == 0  # Nothing injected yet
     pyboy.button("start")
-    assert len(pyboy.events) == 1 # Button press immediately
+    assert len(pyboy.events) == 1  # Button press immediately
     assert pyboy.events[0].event == WindowEvent.PRESS_BUTTON_START
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 1 # Button release delayed
+    assert len(pyboy.events) == 1  # Button release delayed
     assert pyboy.events[0].event == WindowEvent.RELEASE_BUTTON_START
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 0 # No input
+    assert len(pyboy.events) == 0  # No input
 
-    assert len(pyboy.events) == 0 # Nothing injected yet
+    assert len(pyboy.events) == 0  # Nothing injected yet
     pyboy.button("start", 3)
-    assert len(pyboy.events) == 1 # Button press immediately
+    assert len(pyboy.events) == 1  # Button press immediately
     assert pyboy.events[0].event == WindowEvent.PRESS_BUTTON_START
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 0 # No input
+    assert len(pyboy.events) == 0  # No input
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 0 # No input
+    assert len(pyboy.events) == 0  # No input
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 1 # Button release delayed
+    assert len(pyboy.events) == 1  # Button release delayed
     assert pyboy.events[0].event == WindowEvent.RELEASE_BUTTON_START
     pyboy.tick(1, False)
-    assert len(pyboy.events) == 0 # No input
+    assert len(pyboy.events) == 0  # No input

--- a/tests/test_game_wrapper.py
+++ b/tests/test_game_wrapper.py
@@ -35,20 +35,20 @@ def test_game_wrapper_sprites_tall(default_rom):
     pyboy.tick(120)
 
     pyboy.memory[LCDC_OFFSET] = (
-        0b10000000 | # LCD On
-        0b10000100 | # Sprites 8x16
-        0b10000010 # Sprites on
+        0b10000000  # LCD On
+        | 0b10000100  # Sprites 8x16
+        | 0b10000010  # Sprites on
     )
 
-    pyboy.memory[VRAM_OFFSET:VRAM_OFFSET + 0x2000] = 0x00 # Clear all tile data!
-    pyboy.memory[VRAM_OFFSET:VRAM_OFFSET + 32] = 0xFF # First 2 tiles are black
+    pyboy.memory[VRAM_OFFSET : VRAM_OFFSET + 0x2000] = 0x00  # Clear all tile data!
+    pyboy.memory[VRAM_OFFSET : VRAM_OFFSET + 32] = 0xFF  # First 2 tiles are black
 
     for y in [0, 8, 16, 24]:
-        pyboy.memory[OAM_OFFSET:OAM_OFFSET + 4] = [
-            y, # Y: Value -16, so above the screen and move down
-            16, # X: A bit out
-            0, # Tile index 0
-            0, # Attributes
+        pyboy.memory[OAM_OFFSET : OAM_OFFSET + 4] = [
+            y,  # Y: Value -16, so above the screen and move down
+            16,  # X: A bit out
+            0,  # Tile index 0
+            0,  # Attributes
         ]
         pyboy.tick(1)
 
@@ -71,44 +71,53 @@ def test_game_wrapper_mapping(default_rom):
     assert generic_wrapper is not None
     pyboy.tick(5, True)
     assert np.all(
-        pyboy.game_area()[8:11,
-                          8:13] == np.array([
-                              [1, 0, 1, 0, 0],
-                              [2, 3, 4, 5, 3],
-                              [0, 6, 0, 0, 6],
-                          ], dtype=np.uint32)
+        pyboy.game_area()[8:11, 8:13]
+        == np.array(
+            [
+                [1, 0, 1, 0, 0],
+                [2, 3, 4, 5, 3],
+                [0, 6, 0, 0, 6],
+            ],
+            dtype=np.uint32,
+        )
     )
 
     # List-based mapping, don't call tick
-    mapping = [x for x in range(384)] # 1:1 mapping
+    mapping = [x for x in range(384)]  # 1:1 mapping
     mapping[0] = 10
     mapping[1] = 10
     mapping[2] = 10
     mapping[3] = 10
     pyboy.game_area_mapping(mapping, 1000)
     assert np.all(
-        pyboy.game_area()[8:11, 8:13] == np.array([
-            [10, 10, 10, 10, 10],
-            [10, 10, 4, 5, 10],
-            [10, 6, 10, 10, 6],
-        ],
-                                                  dtype=np.uint32)
+        pyboy.game_area()[8:11, 8:13]
+        == np.array(
+            [
+                [10, 10, 10, 10, 10],
+                [10, 10, 4, 5, 10],
+                [10, 6, 10, 10, 6],
+            ],
+            dtype=np.uint32,
+        )
     )
 
     # Array-based mapping, don't call tick
     mapping = np.asarray(mapping)
-    mapping[0] = 1 # Map tile identifier 0 -> 1
-    mapping[1] = 1 # Map tile identifier 1 -> 1
-    mapping[2] = 1 # Map tile identifier 2 -> 1
-    mapping[3] = 1 # Map tile identifier 3 -> 1
+    mapping[0] = 1  # Map tile identifier 0 -> 1
+    mapping[1] = 1  # Map tile identifier 1 -> 1
+    mapping[2] = 1  # Map tile identifier 2 -> 1
+    mapping[3] = 1  # Map tile identifier 3 -> 1
     pyboy.game_area_mapping(mapping, 1000)
     assert np.all(
-        pyboy.game_area()[8:11,
-                          8:13] == np.array([
-                              [1, 1, 1, 1, 1],
-                              [1, 1, 4, 5, 1],
-                              [1, 6, 1, 1, 6],
-                          ], dtype=np.uint32)
+        pyboy.game_area()[8:11, 8:13]
+        == np.array(
+            [
+                [1, 1, 1, 1, 1],
+                [1, 1, 4, 5, 1],
+                [1, 6, 1, 1, 6],
+            ],
+            dtype=np.uint32,
+        )
     )
 
     pyboy.stop()

--- a/tests/test_game_wrapper_mario.py
+++ b/tests/test_game_wrapper_mario.py
@@ -58,7 +58,7 @@ def test_mario_game_over(supermarioland_rom):
     mario.start_game()
     mario.set_lives_left(0)
     pyboy.button_press("right")
-    for _ in range(500): # Enough to game over correctly, and not long enough it'll work without setting the lives
+    for _ in range(500):  # Enough to game over correctly, and not long enough it'll work without setting the lives
         pyboy.tick(1, False)
         if mario.game_over():
             break

--- a/tests/test_game_wrapper_pokemon_pinball.py
+++ b/tests/test_game_wrapper_pokemon_pinball.py
@@ -92,7 +92,7 @@ def test_pokemon_catch_mode(pokemon_pinball_rom):
     pyboy.button_release("left")
     pyboy.tick(31, False)
     pyboy.button_press("left")
-    pyboy.tick(400, False) # NOTE: This sequence broke because of changed instruction timings
+    pyboy.tick(400, False)  # NOTE: This sequence broke because of changed instruction timings
 
     assert pokemon_pinball.score == 9030100
     assert not pokemon_pinball.has_pokemon(Pokemon.BULBASAUR)

--- a/tests/test_mario_rl.py
+++ b/tests/test_mario_rl.py
@@ -184,7 +184,7 @@ env.close()
 
 @pytest.mark.skipif(
     os.path.isfile("extras/README/6.gif") or platform.system() == "Windows",
-    reason="This test takes too long for regular use"
+    reason="This test takes too long for regular use",
 )
 def test_mario_rl(git_pyboy_rl, supermarioland_rom):
     script_py = "record_gif.py"
@@ -193,7 +193,10 @@ def test_mario_rl(git_pyboy_rl, supermarioland_rom):
 
     root_path = Path("../")
     assert os.system(f'rm -rf {Path(git_pyboy_rl) / "recordings"}') == 0
-    assert os.system(
-        f'cd {git_pyboy_rl} && . {Path(".venv") / "bin" / "activate"} && python {script_py} {root_path / supermarioland_rom} Super_Mario_Land'
-    ) == 0
+    assert (
+        os.system(
+            f'cd {git_pyboy_rl} && . {Path(".venv") / "bin" / "activate"} && python {script_py} {root_path / supermarioland_rom} Super_Mario_Land'
+        )
+        == 0
+    )
     assert os.system(f'mv {Path(git_pyboy_rl) / "recordings" / "SUPER*"} {Path("extras/README/6.gif")}') == 0

--- a/tests/test_memoryscanner.py
+++ b/tests/test_memoryscanner.py
@@ -52,22 +52,22 @@ def test_memoryscanner_boundary(default_rom):
     # Byte width of 1
     pyboy.memory[0xC000:0xD000] = 0
     addresses = pyboy.memory_scanner.scan_memory(0, start_addr=0xC000, end_addr=0xC0FF, byte_width=1)
-    assert len(addresses) == 0x100 # We scan all two-byte addresses from 0, 1, 2, ..., n (including n)
+    assert len(addresses) == 0x100  # We scan all two-byte addresses from 0, 1, 2, ..., n (including n)
 
     pyboy.memory[0xC0FF] = 1
     addresses = pyboy.memory_scanner.scan_memory(0, start_addr=0xC000, end_addr=0xC0FF, byte_width=1)
-    assert len(addresses) == 0x100 - 1 # Where one value is now not 0
+    assert len(addresses) == 0x100 - 1  # Where one value is now not 0
 
     # Byte width of 2
     pyboy.memory[0xC000:0xD000] = 0
     addresses = pyboy.memory_scanner.scan_memory(0, start_addr=0xC000, end_addr=0xC0FF, byte_width=2)
-    assert len(
-        addresses
-    ) == 0x100 - 1 # We scan all two-byte addresses from 0, 1, 2, ..., n-1 (excluding n, as we can't go to n+1 for the second byte)
+    assert (
+        len(addresses) == 0x100 - 1
+    )  # We scan all two-byte addresses from 0, 1, 2, ..., n-1 (excluding n, as we can't go to n+1 for the second byte)
 
     pyboy.memory[0xC0FF] = 1
     addresses = pyboy.memory_scanner.scan_memory(0, start_addr=0xC000, end_addr=0xC0FF, byte_width=2)
-    assert len(addresses) == 0x100 - 1 - 1 # Where one value is now not 0, and we cannot get n+1
+    assert len(addresses) == 0x100 - 1 - 1  # Where one value is now not 0, and we cannot get n+1
 
 
 SCORE_100 = 0xD072

--- a/tests/test_memoryview.py
+++ b/tests/test_memoryview.py
@@ -51,19 +51,19 @@ def test_memoryview(default_rom, boot_rom):
     assert p.memory[0:10] == bootrom_bytes[:10]
 
     # Actually do write to RAM area
-    assert p.memory[0xC000:0xC00a] == [0] * 10
-    p.memory[0xC000:0xC00a] = 123
-    assert p.memory[0xC000:0xC00a] == [123] * 10
+    assert p.memory[0xC000:0xC00A] == [0] * 10
+    p.memory[0xC000:0xC00A] = 123
+    assert p.memory[0xC000:0xC00A] == [123] * 10
 
     # Attempt to write slice to ROM area
     p.memory[0:5] = [0, 1, 2, 3, 4]
     assert p.memory[0:10] == bootrom_bytes[:10]
 
     # Actually do write slice to RAM area
-    p.memory[0xC000:0xC00a] = [0] * 10
-    assert p.memory[0xC000:0xC00a] == [0] * 10
-    p.memory[0xC000:0xC00a] = [1] * 10
-    assert p.memory[0xC000:0xC00a] == [1] * 10
+    p.memory[0xC000:0xC00A] = [0] * 10
+    assert p.memory[0xC000:0xC00A] == [0] * 10
+    p.memory[0xC000:0xC00A] = [1] * 10
+    assert p.memory[0xC000:0xC00A] == [1] * 10
 
     # Attempt to write too large memory slice into memory area
     with pytest.raises(AssertionError):
@@ -71,7 +71,7 @@ def test_memoryview(default_rom, boot_rom):
 
     # Attempt to write too small memory slice into memory area
     with pytest.raises(AssertionError):
-        p.memory[0xC000:0xC00a] = [1] * 2
+        p.memory[0xC000:0xC00A] = [1] * 2
 
     # Read specific ROM bank
     assert p.memory[0, 0x00:0x10] == rom_bytes[:16]
@@ -95,7 +95,7 @@ def test_memoryview(default_rom, boot_rom):
         p.memory[0, 0x00:0x9000]
 
 
-def test_cgb_banks(cgb_acid_file): # Any CGB file
+def test_cgb_banks(cgb_acid_file):  # Any CGB file
     p = PyBoy(cgb_acid_file)
 
     # Read VRAM banks through both aliases
@@ -131,10 +131,10 @@ def test_cgb_banks(cgb_acid_file): # Any CGB file
         p.memory[0:2, 0xD000:0xD010] = 1
 
     with pytest.raises(AssertionError):
-        p.memory[8, 0xD000] # Only bank 0-7
+        p.memory[8, 0xD000]  # Only bank 0-7
 
     with pytest.raises(AssertionError):
-        p.memory[8, 0xD000] = 1 # Only bank 0-7
+        p.memory[8, 0xD000] = 1  # Only bank 0-7
 
 
 def test_get_set_override(default_rom):
@@ -146,15 +146,15 @@ def test_get_set_override(default_rom):
     pyboy.memory[0xFF40] = 0x12
     assert pyboy.memory[0xFF40] == 0x12
 
-    assert pyboy.memory[0, 0x0002] == 0x42 # Taken from ROM bank 0
-    assert pyboy.memory[0x0002] == 0xFF # Taken from bootrom
-    assert pyboy.memory[-1, 0x0002] == 0xFF # Taken from bootrom
-    pyboy.memory[-1, 0x0002] = 0x01 # Change bootrom
-    assert pyboy.memory[-1, 0x0002] == 0x01 # New value in bootrom
-    assert pyboy.memory[0, 0x0002] == 0x42 # Taken from ROM bank 0
+    assert pyboy.memory[0, 0x0002] == 0x42  # Taken from ROM bank 0
+    assert pyboy.memory[0x0002] == 0xFF  # Taken from bootrom
+    assert pyboy.memory[-1, 0x0002] == 0xFF  # Taken from bootrom
+    pyboy.memory[-1, 0x0002] = 0x01  # Change bootrom
+    assert pyboy.memory[-1, 0x0002] == 0x01  # New value in bootrom
+    assert pyboy.memory[0, 0x0002] == 0x42  # Taken from ROM bank 0
 
-    pyboy.memory[0xFF50] = 1 # Disable bootrom
-    assert pyboy.memory[0x0002] == 0x42 # Taken from ROM bank 0
+    pyboy.memory[0xFF50] = 1  # Disable bootrom
+    assert pyboy.memory[0x0002] == 0x42  # Taken from ROM bank 0
 
     pyboy.memory[0, 0x0002] = 0x12
     assert pyboy.memory[0x0002] == 0x12
@@ -170,22 +170,22 @@ def test_boundaries(default_rom):
     # Boot ROM boundary - Expecting 0 to 0xFF both including to change
     assert pyboy.memory[-1, 0x00] != 0
     assert pyboy.memory[-1, 0xFF] != 0
-    pyboy.memory[-1, 0:0x100] = [0] * 0x100 # Clear boot ROM
+    pyboy.memory[-1, 0:0x100] = [0] * 0x100  # Clear boot ROM
     with pytest.raises(AssertionError):
-        pyboy.memory[-1, 0:0x101] = [0] * 0x101 # Out of bounds
+        pyboy.memory[-1, 0:0x101] = [0] * 0x101  # Out of bounds
     assert pyboy.memory[-1, 0x00] == 0
     assert pyboy.memory[-1, 0xFF] == 0
 
-    pyboy.memory[0xFF50] = 1 # Disable bootrom
+    pyboy.memory[0xFF50] = 1  # Disable bootrom
 
     pyboy.memory[0, 0x0000] = 123
     pyboy.memory[0, 0x3FFF] = 123
-    pyboy.memory[1, 0x4000] = 123 # Notice bank! [0,0x4000] would wrap around to 0
+    pyboy.memory[1, 0x4000] = 123  # Notice bank! [0,0x4000] would wrap around to 0
 
     # ROM Bank 0 boundary - Expecting 0 to 0x3FFF both including to change
     pyboy.memory[0, 0:0x4000] = [0] * 0x4000
     with pytest.raises(AssertionError):
-        pyboy.memory[0, 0:0x4001] = [0] * 0x4001 # Over boundary!
+        pyboy.memory[0, 0:0x4001] = [0] * 0x4001  # Over boundary!
 
     # NOTE: Not specifying bank! Defaulting to 0 up to 0x3FFF and then 1 at 0x4000
     assert pyboy.memory[0x0000] == 0

--- a/tests/test_mooneye.py
+++ b/tests/test_mooneye.py
@@ -37,7 +37,6 @@ saved_state = None
         # (False, "misc/boot_regs-cgb.gb"),
         # (False, "misc/ppu/vblank_stat_intr-C.gb"),
         # (False, "misc/bits/unused_hwio-C.gb"),
-
         # (False, "utils/bootrom_dumper.gb"),
         # (False, "utils/dump_boot_hwio.gb"),
         (False, "manual-only/sprite_priority.gb"),
@@ -144,7 +143,7 @@ saved_state = None
         (True, "emulator-only/mbc1/multicart_rom_8Mb.gb"),
         (True, "emulator-only/mbc1/rom_8Mb.gb"),
         (True, "emulator-only/mbc1/rom_16Mb.gb"),
-    ]
+    ],
 )
 def test_mooneye(clean, rom, mooneye_dir, default_rom):
     global saved_state

--- a/tests/test_pokemon_rl.py
+++ b/tests/test_pokemon_rl.py
@@ -116,9 +116,8 @@ if __name__ == '__main__':
 
 
 @pytest.mark.skipif(
-    True or \
-    os.path.isfile("extras/README/8.gif") or platform.system() == "Windows",
-    reason="This test takes too long for regular use"
+    True or os.path.isfile("extras/README/8.gif") or platform.system() == "Windows",
+    reason="This test takes too long for regular use",
 )
 def test_pokemon_rl(git_pokemon_red_experiments, pokemon_red_rom):
     script_py = "record_gif.py"
@@ -127,7 +126,10 @@ def test_pokemon_rl(git_pokemon_red_experiments, pokemon_red_rom):
 
     root_path = Path("../")
     assert os.system(f'rm -rf {Path(git_pokemon_red_experiments) / "recordings"}') == 0
-    assert os.system(
-        f'cp "{pokemon_red_rom}" {git_pokemon_red_experiments}/PokemonRed.gb && cd {git_pokemon_red_experiments}/baselines && . {"../" / Path(".venv") / "bin" / "activate"} && python {script_py}'
-    ) == 0
+    assert (
+        os.system(
+            f'cp "{pokemon_red_rom}" {git_pokemon_red_experiments}/PokemonRed.gb && cd {git_pokemon_red_experiments}/baselines && . {"../" / Path(".venv") / "bin" / "activate"} && python {script_py}'
+        )
+        == 0
+    )
     assert os.system(f'mv {Path(git_pokemon_red_experiments) / "recordings" / "SUPER*"} {Path("README/8.gif")}') == 0

--- a/tests/test_pyboy_lcd.py
+++ b/tests/test_pyboy_lcd.py
@@ -29,16 +29,16 @@ cgb_color_palette = (
 class TestLCD:
     def test_set_stat_mode(self):
         lcd = LCD(False, False, color_palette, cgb_color_palette)
-        lcd._STAT._mode = 2 # Set mode 2 manually
-        assert lcd._STAT._mode == 2 # Init value
-        assert lcd._STAT.set_mode(2) == 0 # Already set
+        lcd._STAT._mode = 2  # Set mode 2 manually
+        assert lcd._STAT._mode == 2  # Init value
+        assert lcd._STAT.set_mode(2) == 0  # Already set
 
-        lcd._STAT._mode = 0 # Set any mode that isn't 1
-        assert lcd._STAT.set_mode(1) == 0 # Newly set, but no interrupt
+        lcd._STAT._mode = 0  # Set any mode that isn't 1
+        assert lcd._STAT.set_mode(1) == 0  # Newly set, but no interrupt
 
-        lcd._STAT._mode = 0 # Set any mode that isn't 1
-        lcd.set_stat(1 << (1 + 3)) # Set mode 1 as interrupting
-        assert lcd._STAT.set_mode(1) == INTR_LCDC # Newly set, now interrupting
+        lcd._STAT._mode = 0  # Set any mode that isn't 1
+        lcd.set_stat(1 << (1 + 3))  # Set mode 1 as interrupting
+        assert lcd._STAT.set_mode(1) == INTR_LCDC  # Newly set, now interrupting
 
     def test_stat_register(self):
         # The Cycle Accurate Game Boy Docs
@@ -46,17 +46,17 @@ class TestLCD:
         # 3 LSB are read-only
 
         lcd = LCD(False, False, color_palette, cgb_color_palette)
-        lcd.set_lcdc(0b1000_0000) # Turn on LCD. Don't care about rest of the flags
-        lcd._STAT.value &= 0b11111000 # Force LY=LYC and mode bits to 0
+        lcd.set_lcdc(0b1000_0000)  # Turn on LCD. Don't care about rest of the flags
+        lcd._STAT.value &= 0b11111000  # Force LY=LYC and mode bits to 0
         lcd.set_stat(
             0b0111_1111
-        ) # Try to clear top bit, to check that it still returns 1. Try setting 3 LSB (read-only).
-        assert (lcd.get_stat() & 0b1000_0000) == 0x80 # LCD on bit (read-only) will not be affected
+        )  # Try to clear top bit, to check that it still returns 1. Try setting 3 LSB (read-only).
+        assert (lcd.get_stat() & 0b1000_0000) == 0x80  # LCD on bit (read-only) will not be affected
         assert (lcd.get_stat() & 0b0000_0111) == 0b000
 
-        assert (lcd.get_stat() & 0b11) == 0b00 # Check that we can read out screen mode
+        assert (lcd.get_stat() & 0b11) == 0b00  # Check that we can read out screen mode
         lcd._STAT.set_mode(2)
-        assert (lcd.get_stat() & 0b11) == 0b10 # Check that we can read out screen mode
+        assert (lcd.get_stat() & 0b11) == 0b10  # Check that we can read out screen mode
 
         # lcd.set_stat(0b0111_1111) # Clear top bit, to check that it still returns 1
 
@@ -65,22 +65,22 @@ class TestLCD:
 
         lcd.LYC = 0
         lcd.LY = 0
-        assert not lcd.get_stat() & 0b100 # LYC flag not set
-        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == 0 # Interrupts not enabled
-        assert lcd.get_stat() & 0b100 # LYC flag set
+        assert not lcd.get_stat() & 0b100  # LYC flag not set
+        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == 0  # Interrupts not enabled
+        assert lcd.get_stat() & 0b100  # LYC flag set
 
         lcd.LYC = 0
         lcd.LY = 1
-        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == 0 # LYC!=LY, and no interrupts enabled
-        assert not lcd.get_stat() & 0b100 # LYC flag automatically cleared
+        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == 0  # LYC!=LY, and no interrupts enabled
+        assert not lcd.get_stat() & 0b100  # LYC flag automatically cleared
 
         lcd.LYC = 0
         lcd.LY = 0
-        lcd.set_stat(0b0100_0000) # Enable LYC==LY interrupt
-        assert not (lcd.get_stat() & 0b100) # LYC flag not set
-        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == INTR_LCDC # Trigger on seting LYC flag
-        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == INTR_LCDC # Also trigger on second call
-        assert lcd.get_stat() & 0b100 # LYC flag set
+        lcd.set_stat(0b0100_0000)  # Enable LYC==LY interrupt
+        assert not (lcd.get_stat() & 0b100)  # LYC flag not set
+        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == INTR_LCDC  # Trigger on seting LYC flag
+        assert lcd._STAT.update_LYC(lcd.LYC, lcd.LY) == INTR_LCDC  # Also trigger on second call
+        assert lcd.get_stat() & 0b100  # LYC flag set
 
 
 @pytest.mark.skipif(not is_pypy, reason="This test requires access to internal registers not available in Cython")
@@ -108,8 +108,8 @@ class TestRenderer:
                 colorcode_low = renderer.colorcode_table[(byte1 & 0xF) | ((byte2 & 0xF) << 4)]
                 colorcode_high = renderer.colorcode_table[((byte1 >> 4) & 0xF) | (byte2 & 0xF0)]
                 for offset in range(4):
-                    assert (colorcode_low >> (3-offset) * 8) & 0xFF == color_code(byte1, byte2, offset)
-                    assert (colorcode_high >> (3-offset) * 8) & 0xFF == color_code(byte1, byte2, offset + 4)
+                    assert (colorcode_low >> (3 - offset) * 8) & 0xFF == color_code(byte1, byte2, offset)
+                    assert (colorcode_high >> (3 - offset) * 8) & 0xFF == color_code(byte1, byte2, offset + 4)
 
     # def test_tick(self):
     #     lcd = LCD()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -33,11 +33,13 @@ def verify_screen_image_np(pyboy, saved_array):
     match = np.all(np.frombuffer(saved_array, dtype=np.uint8).reshape(144, 160, 3) == pyboy.screen.ndarray)
     if not match and os.environ.get("TEST_VERBOSE_IMAGES"):
         from PIL import Image
+
         original = Image.frombytes("RGB", (160, 144), np.frombuffer(saved_array, dtype=np.uint8).reshape(144, 160, 3))
         original.show()
         new = pyboy.screen.image.convert("RGB")
         new.show()
         import PIL.ImageChops
+
         PIL.ImageChops.difference(original, new).show()
 
     assert match
@@ -107,9 +109,12 @@ def replay(
     # Filters out the blacklisted events
     recorded_input = list(
         map(
-            lambda event_tuple:
-            (event_tuple[0], list(filter(lambda x: x not in event_filter, event_tuple[1])), event_tuple[2]),
-            recorded_input
+            lambda event_tuple: (
+                event_tuple[0],
+                list(filter(lambda x: x not in event_filter, event_tuple[1])),
+                event_tuple[2],
+            ),
+            recorded_input,
         )
     )
 
@@ -126,7 +131,7 @@ def replay(
             for e in next_event[1]:
                 pyboy.send_input(e)
 
-                if verify and not overwrite and frame_count > 1: # First frame or two might be wrong on old statefiles
+                if verify and not overwrite and frame_count > 1:  # First frame or two might be wrong on old statefiles
                     verify_screen_image_np(pyboy, base64.b64decode(next_event[2].encode("utf8")))
             next_event = recorded_input.pop(0)
         frame_count += 1

--- a/tests/test_rewind.py
+++ b/tests/test_rewind.py
@@ -5,8 +5,13 @@ import pytest
 is_pypy = platform.python_implementation() == "PyPy"
 
 if is_pypy:
-    from pyboy.plugins.rewind import DeltaFixedAllocBuffers, CompressedFixedAllocBuffers, FixedAllocBuffers, \
-                                    FILL_VALUE, FIXED_BUFFER_SIZE
+    from pyboy.plugins.rewind import (
+        FILL_VALUE,
+        FIXED_BUFFER_SIZE,
+        CompressedFixedAllocBuffers,
+        DeltaFixedAllocBuffers,
+        FixedAllocBuffers,
+    )
 
 
 def write_bytes(buf, values):
@@ -130,7 +135,7 @@ class TestRewind:
         assert all(
             map(
                 lambda x: x[0] == x[1],
-                zip(buf.buffer[:60], [0, 1] + list(range(1, 20)) + [0x80] * 20 + [FILL_VALUE] * 20)
+                zip(buf.buffer[:60], [0, 1] + list(range(1, 20)) + [0x80] * 20 + [FILL_VALUE] * 20),
             )
         )
         assert all(map(lambda x: x[0] == x[1], zip(buf.internal_buffer[:60], list(range(0x80, 0x80 + 20)) + [0] * 40)))
@@ -142,8 +147,8 @@ class TestRewind:
                 lambda x: x[0] == x[1],
                 zip(
                     buf.buffer[:61],
-                    [0, 1] + list(range(1, 20)) + [0x80] * 20 + [x ^ 0xFF for x in list(range(0x80, 0x80 + 20))]
-                )
+                    [0, 1] + list(range(1, 20)) + [0x80] * 20 + [x ^ 0xFF for x in list(range(0x80, 0x80 + 20))],
+                ),
             )
         )
         assert all(map(lambda x: x[0] == x[1], zip(buf.internal_buffer[:60], [0xFF] * 20 + [0] * 40)))
@@ -180,7 +185,7 @@ class TestRewind:
         buf = FixedAllocBuffers()
         # Fill almost entire buffer, as we want this section to be removed when we write more than the buffer can
         # contain.
-        write_bytes(buf, [0xAA] * (FIXED_BUFFER_SIZE-10))
+        write_bytes(buf, [0xAA] * (FIXED_BUFFER_SIZE - 10))
         buf.new()
         # We should have the first [0] section plus the one above.
         assert len(buf.sections) == 2

--- a/tests/test_samesuite.py
+++ b/tests/test_samesuite.py
@@ -25,7 +25,8 @@ saved_state = None
 
 
 @pytest.mark.parametrize(
-    "clean, gb_type, rom", [
+    "clean, gb_type, rom",
+    [
         (True, "dmg", "interrupt/ei_delay_halt.gb"),
         (True, "dmg", "apu/div_write_trigger.gb"),
         (True, "dmg", "apu/div_write_trigger_volume_10.gb"),
@@ -104,7 +105,7 @@ saved_state = None
         (True, "cgb", "dma/hdma_lcd_off.gb"),
         (True, "cgb", "dma/gbc_dma_cont.gb"),
         (True, "dmg", "ppu/blocking_bgpi_increase.gb"),
-    ]
+    ],
 )
 def test_samesuite(clean, gb_type, rom, samesuite_dir, boot_cgb_rom, boot_rom, default_rom):
     global saved_state

--- a/tests/test_shonumi.py
+++ b/tests/test_shonumi.py
@@ -14,10 +14,13 @@ import pytest
 from pyboy import PyBoy
 
 
-@pytest.mark.parametrize("rom", [
-    "LYC.gb",
-    "sprite_suite.gb",
-])
+@pytest.mark.parametrize(
+    "rom",
+    [
+        "LYC.gb",
+        "sprite_suite.gb",
+    ],
+)
 def test_shonumi(rom, shonumi_dir):
     pyboy = PyBoy(shonumi_dir + rom, window="null", color_palette=(0xFFFFFF, 0x999999, 0x606060, 0x000000))
     pyboy.set_emulation_speed(0)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -29,7 +29,7 @@ def test_load_save_consistency(tetris_rom):
     while True:
         pyboy.tick(1, True)
         tilemap_background = pyboy.tilemap_background
-        if tilemap_background[2:9, 14] == [89, 25, 21, 10, 34, 14, 27]: # '1PLAYER' on the first screen
+        if tilemap_background[2:9, 14] == [89, 25, 21, 10, 34, 14, 27]:  # '1PLAYER' on the first screen
             break
 
     # Start game. Just press Start when the game allows us.

--- a/tests/test_tetris_ai.py
+++ b/tests/test_tetris_ai.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
 
 @pytest.mark.skipif(
     os.path.isfile("extras/README/7.gif") or platform.system() == "Windows",
-    reason="This test takes too long for regular use"
+    reason="This test takes too long for regular use",
 )
 def test_tetris_ai(git_tetris_ai, tetris_rom):
     script_py = "tetris_gif.py"


### PR DESCRIPTION

This update ensures that `Sprites` consisting of two `Tiles` are fully added in the game area matrix provided by the GameWrapper plugin in `pyboy.game_area()` or `pyboy.game_wrapper.game_area()`


### Bug fixed:

- Only the first tile was placed, leading to incomplete game area representations depending on the game.

###  Why Is It Important?

When training an AI model, the most common approach is to directly use game_area as a parameter. Some games use sprites composed of two tiles. Since understanding the Game Boy's sprite and tile system is not necessarily required for training a model, this issue can be difficult to debug.

As a result, those who notice something wrong with game_area might not realize that this is the root cause of the problem. This could have a significant impact while going unnoticed.

####  Another question:

I have some minor modifications for the GameWrapper that do not affect its behavior but improve the code in terms of readability and use of constants. It’s only a few lines, and you can check the code in this branch of my fork: [https://github.com/BackrndSource/PyBoy/tree/GameWrapper__pretty](https://github.com/BackrndSource/PyBoy/tree/GameWrapper__pretty)

Should I add it to this pull request or create a new one?
