### PR TITLE
Update WindowEvent.__eq__

### DIFF
--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -230,7 +230,7 @@ class WindowSDL2(PyBoyWindowPlugin):
     def handle_events(self, events):
         events = sdl2_event_pump(events)
         for e in events:
-            if e.event == WindowEvent.FULL_SCREEN_TOGGLE:
+            if e == WindowEvent.FULL_SCREEN_TOGGLE:
                 if self.fullscreen:
                     sdl2.SDL_SetWindowFullscreen(self._window, 0)
                 else:

--- a/pyboy/utils.pxd
+++ b/pyboy/utils.pxd
@@ -39,10 +39,9 @@ cdef inline uint64_t double_to_uint64_ceil(double val) noexcept nogil:
 
 ##############################################################
 # Window Events
-# Temporarily placed here to not be exposed on public API
 
 cdef class WindowEvent:
-    cdef readonly int event
+    cdef readonly int __event
 
 cdef class WindowEventMouse(WindowEvent):
     cdef readonly int window_id

--- a/pyboy/utils.pxd
+++ b/pyboy/utils.pxd
@@ -32,8 +32,6 @@ cdef class IntIOWrapper(IntIOInterface):
 ##############################################################
 # Misc
 
-cpdef uint8_t color_code(uint8_t, uint8_t, uint8_t) noexcept nogil
-
 cdef inline uint64_t double_to_uint64_ceil(double val) noexcept nogil:
     return <uint64_t> ceil(val)
 

--- a/pyboy/utils.py
+++ b/pyboy/utils.py
@@ -351,11 +351,12 @@ class WindowEvent:
     def __init__(self, event):
         self.event = event
 
-    def __eq__(self, x):
-        if isinstance(x, int):
-            return self.event == x
-        else:
-            return self.event == x.event
+    def __eq__(self, other):
+        if isinstance(other, WindowEvent):
+            return self.event == other.event
+        elif isinstance(other, int):
+            return self.event == other
+        return NotImplemented
 
     def __int__(self):
         return self.event

--- a/pyboy/utils.py
+++ b/pyboy/utils.py
@@ -255,22 +255,6 @@ class IntIOWrapper(IntIOInterface):
 ##############################################################
 # Misc
 
-
-# NOTE: Legacy function. Use look-up table in Renderer
-def color_code(byte1, byte2, offset):
-    """Convert 2 bytes into color code at a given offset.
-
-    The colors are 2 bit and are found like this:
-
-    Color of the first pixel is 0b10
-    | Color of the second pixel is 0b01
-    v v
-    1 0 0 1 0 0 0 1 <- byte1
-    0 1 1 1 1 1 0 0 <- byte2
-    """
-    return (((byte2 >> (offset)) & 0b1) << 1) + ((byte1 >> (offset)) & 0b1)
-
-
 if not cython_compiled:
     exec(
         """
@@ -281,6 +265,7 @@ def double_to_uint64_ceil(val):
     )
 
 ##############################################################
+
 # Window Events
 # Temporarily placed here to not be exposed on public API
 

--- a/pyboy/utils.py
+++ b/pyboy/utils.py
@@ -349,17 +349,17 @@ class WindowEvent:
     ) = range(42)
 
     def __init__(self, event):
-        self.event = event
+        self.__event = event
 
     def __eq__(self, other):
         if isinstance(other, WindowEvent):
-            return self.event == other.event
+            return self.__event == other.__event
         elif isinstance(other, int):
-            return self.event == other
+            return self.__event == other
         return NotImplemented
 
     def __int__(self):
-        return self.event
+        return self.__event
 
     def __str__(self):
         return (
@@ -405,7 +405,7 @@ class WindowEvent:
             "MOD_SHIFT_ON",
             "MOD_SHIFT_OFF",
             "FULL_SCREEN_TOGGLE",
-        )[self.event]
+        )[self.__event]
 
 
 class WindowEventMouse(WindowEvent):

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -524,23 +524,23 @@ def test_button(default_rom):
     assert len(pyboy.events) == 0  # Nothing injected yet
     pyboy.button("start")
     assert len(pyboy.events) == 1  # Button press immediately
-    assert pyboy.events[0].event == WindowEvent.PRESS_BUTTON_START
+    assert pyboy.events[0] == WindowEvent.PRESS_BUTTON_START
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 1  # Button release delayed
-    assert pyboy.events[0].event == WindowEvent.RELEASE_BUTTON_START
+    assert pyboy.events[0] == WindowEvent.RELEASE_BUTTON_START
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 0  # No input
 
     assert len(pyboy.events) == 0  # Nothing injected yet
     pyboy.button("start", 3)
     assert len(pyboy.events) == 1  # Button press immediately
-    assert pyboy.events[0].event == WindowEvent.PRESS_BUTTON_START
+    assert pyboy.events[0] == WindowEvent.PRESS_BUTTON_START
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 0  # No input
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 0  # No input
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 1  # Button release delayed
-    assert pyboy.events[0].event == WindowEvent.RELEASE_BUTTON_START
+    assert pyboy.events[0] == WindowEvent.RELEASE_BUTTON_START
     pyboy.tick(1, False, False)
     assert len(pyboy.events) == 0  # No input

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,67 @@
+import pytest
+
+from pyboy.utils import WindowEvent
+
+
+def test_window_event_equality_with_window_event():
+    event1 = WindowEvent(WindowEvent.PAUSE)
+    event2 = WindowEvent(WindowEvent.PAUSE)
+    event3 = WindowEvent(WindowEvent.QUIT)
+    assert event1 == event2
+    assert event1 != event3
+
+
+def test_window_event_equality_with_int():
+    event = WindowEvent(WindowEvent.QUIT)
+    assert event == WindowEvent.QUIT
+    assert event != WindowEvent.PAUSE
+
+
+@pytest.mark.parametrize("invalid_value", ["string", None, 3.14, []])
+def test_window_event_inequality_with_other_types(invalid_value):
+    event = WindowEvent(WindowEvent.PAUSE)
+    assert event != invalid_value
+
+
+def test_window_event_integer_conversion():
+    event = WindowEvent(WindowEvent.PAUSE)
+    assert int(event) == WindowEvent.PAUSE
+
+
+@pytest.mark.parametrize(
+    "event_int, event_name",
+    [
+        (WindowEvent.PAUSE, "PAUSE"),
+        (WindowEvent.QUIT, "QUIT"),
+    ],
+)
+def test_window_event_string_conversion(event_int, event_name):
+    event = WindowEvent(event_int)
+    assert str(event) == event_name
+
+
+def test_window_event_eq_against_other_class():
+    event = WindowEvent(1)
+    assert event.__eq__(1) is True
+    assert event.__eq__(WindowEvent(1)) is True
+
+    # Testing a==b and b==a. This is done by Python when returning 'NotImplemented'
+    class Other:
+        pass
+
+    assert event.__eq__(Other()) is NotImplemented
+    # Doesn't work, because neither class has an __eq__ implementation that fits
+    assert not event == Other()
+
+    class AnOther:
+        def __init__(self, value):
+            self.value = value
+
+        def __eq__(self, value):
+            return int(value) == self.value
+
+    # Although WindowEvent doesn't recognize AnOther,
+    assert event.__eq__(AnOther(1)) is NotImplemented
+    # AnOther recognizes equality to WindowEvent.
+    assert event == AnOther(1)
+    assert event != AnOther(2)


### PR DESCRIPTION
This ensures proper delegation to `other.__eq__` in case of comparisons with unrelated types and avoid raise `AttributeError` when trying to compare with objects not having `event` attribute 