### PR TITLE
Fixed pokemon pinball start game method and associated tests

### DIFF
--- a/pyboy/plugins/game_wrapper_pokemon_pinball.py
+++ b/pyboy/plugins/game_wrapper_pokemon_pinball.py
@@ -597,28 +597,28 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
 
         # Random tilemap I observed doesn't change until shortly before input is read
         while self.tilemap_background[10, 10] != 269:
-            self.pyboy.tick(1, False)
+            self.pyboy.tick(1, False, False)
 
         # tick needed count to get to the point where input is read
-        self.pyboy.tick(18, False)
+        self.pyboy.tick(18, False, False)
 
         # start game
         self.pyboy.send_input(WindowEvent.PRESS_BUTTON_A)
-        self.pyboy.tick(2, False)
+        self.pyboy.tick(2, False, False)
         self.pyboy.send_input(WindowEvent.RELEASE_BUTTON_A)
         # tick count needed to get to the next point where input is read
-        self.pyboy.tick(95, False)
+        self.pyboy.tick(95, False, False)
 
         self.pyboy.send_input(WindowEvent.PRESS_BUTTON_A)
-        self.pyboy.tick(1, False)
+        self.pyboy.tick(1, False, False)
         self.pyboy.send_input(WindowEvent.RELEASE_BUTTON_A)
-        self.pyboy.tick(1, False)
+        self.pyboy.tick(1, False, False)
 
         ticks_until_visible = 74
-        self.pyboy.tick(ticks_until_visible, False)
+        self.pyboy.tick(ticks_until_visible, False, False)
 
         ticks_until_input_ready = 4
-        self.pyboy.tick(ticks_until_input_ready, False)
+        self.pyboy.tick(ticks_until_input_ready, False, False)
 
         # needs to be called after normal initializations, otherwise it will be overwritten
         self._init_bonus_stage(stage)

--- a/pyboy/plugins/game_wrapper_pokemon_pinball.py
+++ b/pyboy/plugins/game_wrapper_pokemon_pinball.py
@@ -604,7 +604,7 @@ class GameWrapperPokemonPinball(PyBoyGameWrapper):
 
         # start game
         self.pyboy.send_input(WindowEvent.PRESS_BUTTON_A)
-        self.pyboy.tick(1, False)
+        self.pyboy.tick(2, False)
         self.pyboy.send_input(WindowEvent.RELEASE_BUTTON_A)
         # tick count needed to get to the next point where input is read
         self.pyboy.tick(95, False)

--- a/tests/test_game_wrapper_pokemon_pinball.py
+++ b/tests/test_game_wrapper_pokemon_pinball.py
@@ -16,8 +16,8 @@ def test_pokemon_pinball_basics(pokemon_pinball_rom):
     pokemon_pinball.start_game(timer_div=0x00)
 
     assert pokemon_pinball.score == 0
-    assert pokemon_pinball.balls_left == 3
-    assert pokemon_pinball.current_stage == Stage.RED_TOP.value
+    assert pokemon_pinball.balls_left == 2
+    assert pokemon_pinball.current_stage == Stage.RED_BOTTOM.value
     assert pokemon_pinball.special_mode_active == False
 
 
@@ -40,10 +40,10 @@ def test_pokemon_pinball_advanced(pokemon_pinball_rom):
     pyboy.button_release("left")
     pyboy.button_release("a")
 
-    assert pokemon_pinball.score == 100
+    assert pokemon_pinball.score == 100300
     assert pokemon_pinball.special_mode == SpecialMode.CATCH.value
     assert pokemon_pinball.current_stage == Stage.BLUE_BOTTOM.value
-    assert not pokemon_pinball.special_mode_active
+    assert pokemon_pinball.special_mode_active
     assert pokemon_pinball.balls_left == 2
 
 


### PR DESCRIPTION
After messing around with the wrapper for a bit i noticed the start game method wasnt working how i expected it to. Noticed there were changes to the tests we had before. I changed the test values back on 2 tests now that the start game method works as expected.

It was not registering one of the button releases, I assume due to the timing changes since I last worked with it.