### PR TITLE
Add debug logging for key events in Interaction class

### DIFF
--- a/pyboy/core/interaction.py
+++ b/pyboy/core/interaction.py
@@ -20,8 +20,25 @@ class Interaction:
     def __init__(self):
         self.directional = 0xF
         self.standard = 0xF
+        self.debug = False
+
+    def toggle_debug(self):
+        self.debug = not self.debug
 
     def key_event(self, key):
+        if self.debug:
+            # Try to get the event name, otherwise fall back to the raw value
+            try:
+                # key is usually an int when coming from send_input or tests
+                if isinstance(key, WindowEvent):
+                    # This case might occur if key_event is called internally with an existing WindowEvent instance
+                    event_name = str(key)
+                else:
+                    # Assume key is an integer value, create a WindowEvent instance and get its string form
+                    event_name = str(WindowEvent(key))
+            except (ValueError, IndexError): # IndexError if key is out of range for the tuple in __str__
+                event_name = key # Fallback for values not in enum or if str() fails
+            print(f"Key event: {event_name}")
         _directional = self.directional
         _standard = self.standard
         if key == WindowEvent.PRESS_ARROW_RIGHT:
@@ -59,6 +76,9 @@ class Interaction:
             self.standard = set_bit(self.standard, P12)
         elif key == WindowEvent.RELEASE_BUTTON_START:
             self.standard = set_bit(self.standard, P13)
+
+        if self.debug:
+            print(f"Directional: {self.directional:#0x}, Standard: {self.standard:#0x}")
 
         # XOR to find the changed bits, AND it to see if it was high before.
         # Test for both directional and standard buttons.


### PR DESCRIPTION
This commit introduces a debugging feature to the `Interaction` class to help trace key processing.

Key changes:
- Added a `debug` boolean attribute to the `Interaction` class, initialized to `False`.
- Added a `toggle_debug()` method to flip the state of the `debug` attribute.
- Enhanced the `key_event()` method to print the received key event (as a string name if possible, otherwise the raw value) and the updated `directional` and `standard` button states (in hex format) to stdout when the `debug` flag is `True`.
- Added a new test case `test_interaction_debug_output` in `tests/test_interaction.py`. This test verifies:
    - No output when debugging is off.
    - Correct event name and button states are printed when debugging is on.
    - Output stops when debugging is turned off again.
- Corrected the printing of `WindowEvent` in `key_event` to use `str(WindowEvent(key))` as `WindowEvent` is not a standard Enum and provides its string representation via `__str__`.

This feature allows developers to easily inspect the flow of key events and the resulting state changes within the emulator, aiding in debugging input-related issues.

<!--

Type an explanation of what feature your code adds or which bug it fixes.

Checklist for pull-requests
---------------------------

  1. The project is licensed under LGPL (see LICENSE.md). When merged, your code will be under the same license.
     So make sure you have read and understand it.
  2. Please coordinate with one of the core developers before making a big pull-request.
     It's a shame to make something big that doesn't fit the project.
  3. Remember to make a separate branch on your fork. This makes it a lot easier for the core developers to help
     getting your pull-request ready.
  4. Install `pip install pre-commit`. This takes care of the formatting rules when you commit your code.
  5. Add tests. We need good pytests for your code. This will help us keep the project stable.
  6. Please don't change the code style, unless it's specifically asked for.

-->

