### PR TITLE
fix: persistent src/dest tracking during gdma

### DIFF
--- a/pyboy/core/mb.py
+++ b/pyboy/core/mb.py
@@ -678,12 +678,16 @@ class Motherboard:
                 self.lcd.vbk.set(value)
             elif self.cgb_mode and i == 0xFF51:
                 self.hdma.hdma1 = value
+                self.hdma.curr_src = (value << 8) | (self.hdma.curr_src & 0x00FF)
             elif self.cgb_mode and i == 0xFF52:
                 self.hdma.hdma2 = value  # & 0xF0
+                self.hdma.curr_src = (self.hdma.curr_src & 0xFF00) | (value & 0xF0)
             elif self.cgb_mode and i == 0xFF53:
                 self.hdma.hdma3 = value  # & 0x1F
+                self.hdma.curr_dst = ((value & 0x1F) << 8) | (self.hdma.curr_dst & 0x00FF) | 0x8000
             elif self.cgb_mode and i == 0xFF54:
                 self.hdma.hdma4 = value  # & 0xF0
+                self.hdma.curr_dst = (self.hdma.curr_dst & 0xFF00) | (value & 0xF0)
             elif self.cgb_mode and i == 0xFF55:
                 self.hdma.set_hdma5(value, self)
                 self.cpu.bail = True
@@ -773,22 +777,21 @@ class HDMA:
         else:
             self.hdma5 = value & 0xFF
             bytes_to_transfer = ((value & 0x7F) * 16) + 16
-            src = (self.hdma1 << 8) | (self.hdma2 & 0xF0)
-            dst = ((self.hdma3 & 0x1F) << 8) | (self.hdma4 & 0xF0)
-            dst |= 0x8000
 
             transfer_type = value >> 7
             if transfer_type == 0:
                 # General purpose DMA transfer
+                src = self.curr_src
+                dst = self.curr_dst
                 for i in range(bytes_to_transfer):
                     mb.setitem((dst + i) & 0xFFFF, mb.getitem((src + i) & 0xFFFF))
 
-                # Number of blocks of 16-bytes transfered. Set 7th bit for "completed".
-                self.hdma5 = 0xFF  # (value & 0x7F) | 0x80 #0xFF
-                self.hdma4 = 0xFF
-                self.hdma3 = 0xFF
-                self.hdma2 = 0xFF
-                self.hdma1 = 0xFF
+                self.curr_src = (src + bytes_to_transfer) & 0xFFFF
+                self.curr_dst = (dst + bytes_to_transfer) & 0xFFFF
+
+                # Signals transfer complete (Readable via FF55)
+                self.hdma5 = 0xFF
+
                 # TODO: Progress cpu cycles!
                 # https://gist.github.com/drhelius/3394856
                 # cpu is halted during dma transfer
@@ -797,8 +800,6 @@ class HDMA:
                 # set 7th bit to 0
                 self.hdma5 = self.hdma5 & 0x7F
                 self.transfer_active = True
-                self.curr_dst = dst
-                self.curr_src = src
 
     def tick(self, mb):
         # HBLANK HDMA routine


### PR DESCRIPTION
## Related issue
closes #412 

## Context
It seems that the problem was directly related to this part:

https://github.com/Baekalfen/PyBoy/blob/8015851f5cbf0a21e837eaf3824e1bad3df7547d/pyboy/core/mb.py#L776-L791

AFAIU, we always base the src/dest off of hdma1-4, which is fine most of the time but might cause problems if a game does multiple sequential transfers without re-writing to these registers.

One approach would be to update these registers to point to the next address instead of 0xFF in lines 788-791, but that seemed to stray from the documented hw behavior so I opted to track them internally with the existing curr_src/curr_dst vars instead.

## Changes made
 - curr_src / curr_dst are now set as soon hdma1-4 are written via setitem_io_ports, in the same way the former src/dst local variables in set_hdma5 used to do
 - in the gdma transfer type:
   - we still set hdma5 to 0xff as per [gbdocs](https://gbdev.io/pandocs/CGB_Registers.html#bit-7--0--general-purpose-dma)
   - we now also persist the next src/dst addresses based on where we left off
 - in the hblank transfer:
   - removed curr_src / curr_dst assign considering they are now already set in setitem_io_ports  

## Tests
Polished Crystal now has the expected behavior described in the issue: the pokédex renders nicely now.

Apparently, no regressions in the test suite, but I also couldn't figure out a good way to unit test this change meaningfully. (will gladly accept any pointers on that :) )