### PR TITLE
add support for mp4 + audio and `screen_recorder.py` rewritted to use `FFMPEG` 

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,7 +46,11 @@ jobs:
       if: ${{ contains(matrix.os, 'macos-latest') }}
       run: |
         # Install 'timeout' command
-        brew install coreutils
+        brew install coreutils ffmpeg
+    - name: Setup Windows - ffmpeg
+      if: ${{ contains(matrix.os, 'windows-latest') }}
+      run: |
+        choco install ffmpeg -y
     - name: Build PyBoy
       env:
         CC: "ccache gcc"
@@ -57,7 +61,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install libopengl0 freeglut3-dev -y
+        sudo apt install libopengl0 freeglut3-dev ffmpeg -y
     - name: Run PyTest
       env:
         PYTEST_SECRETS_KEY: ${{ secrets.PYTEST_SECRETS_KEY }}
@@ -110,14 +114,14 @@ jobs:
       if: ${{ contains(matrix.os, 'macos-latest') }}
       run: |
         # Fix cryptography build: https://github.com/pyca/cryptography/issues/3489
-        brew install openssl
+        brew install openssl ffmpeg
         echo "CPPFLAGS=-I/usr/local/opt/openssl/include" >> $GITHUB_ENV
         echo "LDFLAGS=-L/usr/local/opt/openssl/lib" >> $GITHUB_ENV
     - name: Setup Ubuntu - OpenGL dependencies
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install libopengl0 freeglut3-dev
+        sudo apt install libopengl0 freeglut3-dev ffmpeg
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -181,9 +185,10 @@ jobs:
           ln -s "/opt/python/${{ matrix.python-version }}/bin/python3" /usr/local/bin/python
 
           if [[ "${{ matrix.manylinux-version }}" == manylinux_2_28* ]]; then
-            dnf install libjpeg-devel ccache -y
+            dnf install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm -y # ffmpeg
+            dnf install libjpeg-devel ccache ffmpeg -y
           else
-            apk add libjpeg jpeg-dev libffi ccache
+            apk add libjpeg jpeg-dev libffi ccache ffmpeg
             python -m ensurepip
           fi
           ccache --set-config=cache_dir=/ccache

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install libopengl0 freeglut3-dev ffmpeg -y
+        sudo apt install libopengl0 freeglut3-dev ffmpeg libogg-dev -y
     - name: Run PyTest
       env:
         PYTEST_SECRETS_KEY: ${{ secrets.PYTEST_SECRETS_KEY }}
@@ -121,7 +121,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         sudo apt update
-        sudo apt install libopengl0 freeglut3-dev ffmpeg
+        sudo apt install libopengl0 freeglut3-dev ffmpeg libogg-dev -y
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/pyboy/__main__.py
+++ b/pyboy/__main__.py
@@ -185,7 +185,8 @@ The other controls for the emulator:
 | Space        | Unlimited FPS           |
 | Z            | Save state              |
 | X            | Load state              |
-| I            | Toggle screen recording |
+| I            | GIF screen recording    |
+| U            | MP4 screen recording    |
 | O            | Save screenshot         |
 | C            | Cycle DMG palette       |
 | ,            | Rewind backwards        |

--- a/pyboy/plugins/screen_recorder.pxd
+++ b/pyboy/plugins/screen_recorder.pxd
@@ -10,6 +10,7 @@ from pyboy.plugins.base_plugin cimport PyBoyPlugin
 cdef Logger logger
 
 cdef class ScreenRecorder(PyBoyPlugin):
-    cdef bint recording
-    cdef frames
-
+    cdef bint recording_gif
+    cdef bint recording_mp4
+    cdef object ffmpeg_bin
+    cdef object _session

--- a/pyboy/plugins/screen_recorder.py
+++ b/pyboy/plugins/screen_recorder.py
@@ -4,9 +4,13 @@
 #
 
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 
 import pyboy
+from pyboy.api.constants import ROWS, COLS
 from pyboy.plugins.base_plugin import PyBoyPlugin
 from pyboy.utils import WindowEvent
 
@@ -24,56 +28,208 @@ class ScreenRecorder(PyBoyPlugin):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.recording = False
-        self.frames = []
+        self.recording_gif = False
+        self.recording_mp4 = False
+        self.ffmpeg_bin = shutil.which("ffmpeg")
+        self._session = None
 
     def handle_events(self, events):
         for event in events:
             if event == WindowEvent.SCREEN_RECORDING_TOGGLE:
-                self.recording ^= True
-                if not self.recording:
-                    self.save()
+                if self.recording_gif:
+                    self._stop_recording()
                 else:
-                    logger.info("ScreenRecorder started")
+                    self._start_recording("gif")
+                break
+            if event == WindowEvent.SCREEN_RECORDING_TOGGLE_MP4:
+                if self.recording_mp4:
+                    self._stop_recording()
+                else:
+                    self._start_recording("mp4")
                 break
         return events
 
     def post_tick(self):
         # Plugin: Screen Recorder
-        if self.recording:
-            self.add_frame(self.pyboy.screen.image.copy())
+        session = self._session
+        if session is None:
+            return
+        if session["mode"] == "gif":
+            self._capture_gif_frame()
+        else:
+            self._write_frame()
+            self._write_audio()
 
-    def add_frame(self, frame):
-        # Pillow makes artifacts in the output, if we use 'RGB', which is PyBoy's default format
-        self.frames.append(frame)
+    def stop(self):
+        if self.recording_gif or self.recording_mp4:
+            self._stop_recording()
 
-    def save(self, path=None, fps=60):
+    def _start_recording(self, mode):
+        if self.recording_gif or self.recording_mp4:
+            logger.warning("ScreenRecorder already active")
+            return
+
+        if mode == "gif" and Image is None:
+            logger.error('ScreenRecorder gif requires dependency "Pillow"')
+            return
+
+        if mode == "mp4" and not self.mb.sound.emulate:
+            logger.error("ScreenRecorder mp4 requires sound emulation enabled")
+            return
+
+        if mode == "mp4" and self.ffmpeg_bin is None:
+            logger.error('ScreenRecorder mp4 requires dependency "ffmpeg"')
+            return
+
+        directory = os.path.join(os.path.curdir, "recordings")
+        os.makedirs(directory, mode=0o755, exist_ok=True)
+        stamp = time.strftime(f"{self.pyboy.cartridge_title}-%Y.%m.%d-%H.%M.%S")
+        tmpdir = tempfile.mkdtemp(prefix="screenrec-", dir=directory)
+        video_raw = os.path.join(tmpdir, "video.rgba")
+        audio_raw = os.path.join(tmpdir, "audio.s8")
+        output_path = os.path.join(directory, f"{stamp}.{mode}")
+
+        self._session = {
+            "mode": mode,
+            "tmpdir": tmpdir,
+            "video_raw": video_raw if mode == "mp4" else None,
+            "audio_raw": audio_raw if mode == "mp4" else None,
+            "output_path": output_path,
+            "frames": 0,
+            "audio_bytes": 0,
+            "gif_frames": [] if mode == "gif" else None,
+            "video_fh": open(video_raw, "wb") if mode == "mp4" else None,
+            "audio_fh": open(audio_raw, "wb") if mode == "mp4" else None,
+        }
+
+        self.recording_gif = mode == "gif"
+        self.recording_mp4 = mode == "mp4"
+        logger.info("ScreenRecorder started: %s", mode.upper())
+
+    def _stop_recording(self):
+        session = self._session
+        if session is None:
+            return
+
         logger.info("ScreenRecorder saving...")
+        if session["video_fh"] is not None:
+            session["video_fh"].close()
+        if session["audio_fh"] is not None:
+            session["audio_fh"].close()
 
-        if path is None:
-            directory = os.path.join(os.path.curdir, "recordings")
-            if not os.path.exists(directory):
-                os.makedirs(directory, mode=0o755)
-            path = os.path.join(directory, time.strftime(f"{self.pyboy.cartridge_title}-%Y.%m.%d-%H.%M.%S.gif"))
+        success = False
+        if session["frames"] > 0:
+            if session["mode"] == "gif":
+                success = self._encode_gif(session)
+            else:
+                success = self._encode_mp4(session)
+        else:
+            logger.error("Screen recording failed: no frames")
 
-        if len(self.frames) > 0:
-            self.frames[0].save(
-                path,
+        if success:
+            logger.info("Screen recording saved in %s", session["output_path"])
+        self._cleanup_session(session)
+        self._session = None
+        self.recording_gif = False
+        self.recording_mp4 = False
+
+    def _write_frame(self):
+        frame = self.pyboy.screen.ndarray
+        self._session["video_fh"].write(frame.tobytes(order="C"))
+        self._session["frames"] += 1
+
+    def _capture_gif_frame(self):
+        # Keep RGB data for Pillow to avoid palette artifacts.
+        self._session["gif_frames"].append(self.pyboy.screen.image.copy())
+        self._session["frames"] += 1
+
+    def _write_audio(self):
+        audio = self.pyboy.sound.ndarray
+        data = audio.tobytes(order="C")
+        self._session["audio_fh"].write(data)
+        self._session["audio_bytes"] += len(data)
+
+    def _encode_gif(self, session):
+        frames = session["gif_frames"]
+        if not frames:
+            logger.error("Screen recording failed: no frames")
+            return False
+        try:
+            frames[0].save(
+                session["output_path"],
                 save_all=True,
                 interlace=False,
                 loop=0,
                 optimize=True,
-                append_images=self.frames[1:],
-                duration=int(round(1000 / fps, -1)),
+                append_images=frames[1:],
+                duration=int(round(1000 / FPS, -1)),
             )
+            return True
+        except Exception:
+            logger.exception("ScreenRecorder failed to encode GIF")
+            return False
 
-            logger.info("Screen recording saved in {}".format(path))
-        else:
-            logger.error("Screen recording failed: no frames")
-        self.frames = []
+    def _encode_mp4(self, session):
+        if session["audio_bytes"] == 0:
+            logger.error("Screen recording failed: no audio samples were captured")
+            return False
+        return self._run_ffmpeg(
+            [
+                self.ffmpeg_bin,
+                "-y",
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "rgba",
+                "-s:v",
+                f"{COLS}x{ROWS}",
+                "-r",
+                str(FPS),
+                "-i",
+                session["video_raw"],
+                "-f",
+                "s8",
+                "-ar",
+                str(self.pyboy.sound.sample_rate),
+                "-ac",
+                "2",
+                "-i",
+                session["audio_raw"],
+                "-c:v",
+                "libx264",
+                "-preset",
+                "veryfast",
+                "-crf",
+                "18",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                "-shortest",
+                session["output_path"],
+            ]
+        )
+
+    # Execution of ffmpeg commands :)
+    def _run_ffmpeg(self, cmd):
+        proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
+        if proc.returncode != 0:
+            logger.error("ffmpeg failed with code %d", proc.returncode)
+            if proc.stderr:
+                logger.error(proc.stderr.decode(errors="replace"))
+            return False
+        return True
+
+    def _cleanup_session(self, session):
+        if session.get("gif_frames") is not None:
+            session["gif_frames"] = []
+        if os.path.exists(session["tmpdir"]):
+            shutil.rmtree(session["tmpdir"], ignore_errors=True)
 
     def enabled(self):
-        if Image is None:
-            logger.warning('%s: Missing dependency "Pillow". Recording disabled', __name__)
+        if Image is None and self.ffmpeg_bin is None:
+            logger.warning('%s: Missing dependencies "Pillow" and "ffmpeg". Recording disabled', __name__)
             return False
         return True

--- a/pyboy/plugins/window_glfw.py
+++ b/pyboy/plugins/window_glfw.py
@@ -72,6 +72,8 @@ class WindowGLFW(WindowOpenAL):
                 self.events.append(WindowEvent(WindowEvent.PRESS_SPEED_UP))
             elif key == glfw.KEY_I:
                 self.events.append(WindowEvent(WindowEvent.SCREEN_RECORDING_TOGGLE))
+            elif key == glfw.KEY_U:
+                self.events.append(WindowEvent(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4))
             elif key == glfw.KEY_BACKSPACE:
                 self.events.append(WindowEvent(WindowEvent.PRESS_BUTTON_SELECT))
             elif key == glfw.KEY_ENTER:

--- a/pyboy/plugins/window_open_gl.py
+++ b/pyboy/plugins/window_open_gl.py
@@ -150,6 +150,8 @@ class WindowOpenGL(WindowOpenAL):
                 self.events.append(WindowEvent(WindowEvent.PRESS_SPEED_UP))
             elif c == "i":
                 self.events.append(WindowEvent(WindowEvent.SCREEN_RECORDING_TOGGLE))
+            elif c == "u":
+                self.events.append(WindowEvent(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4))
             elif c == chr(8):
                 self.events.append(WindowEvent(WindowEvent.PRESS_BUTTON_SELECT))
             elif c == chr(13):

--- a/pyboy/plugins/window_openal.py
+++ b/pyboy/plugins/window_openal.py
@@ -16,6 +16,9 @@ except Exception as ex:
     if ex.__class__.__name__ == "ExternalLibraryError":
         logger.debug("Error loading OpenAL: %s", ex)
         openal_enabled = False
+    elif "pyogg" in ex.__class__.__name__.lower():
+        logger.debug("Error loading pyogg: %s", ex)
+        openal_enabled = False
     else:
         raise
 

--- a/pyboy/plugins/window_sdl2.py
+++ b/pyboy/plugins/window_sdl2.py
@@ -59,7 +59,8 @@ if sdl2:
         sdl2.SDLK_x         : WindowEvent.STATE_LOAD,
         sdl2.SDLK_SPACE     : WindowEvent.RELEASE_SPEED_UP,
         sdl2.SDLK_p         : WindowEvent.PAUSE_TOGGLE,
-        sdl2.SDLK_i         : WindowEvent.SCREEN_RECORDING_TOGGLE,
+        sdl2.SDLK_i         : WindowEvent.SCREEN_RECORDING_TOGGLE, # gif recording
+        sdl2.SDLK_u         : WindowEvent.SCREEN_RECORDING_TOGGLE_MP4,
         sdl2.SDLK_o         : WindowEvent.SCREENSHOT_RECORD,
         sdl2.SDLK_ESCAPE    : WindowEvent.QUIT,
         sdl2.SDLK_COMMA     : WindowEvent.RELEASE_REWIND_BACK,

--- a/pyboy/utils.py
+++ b/pyboy/utils.py
@@ -360,7 +360,8 @@ class WindowEvent:
         MOD_SHIFT_OFF,
         FULL_SCREEN_TOGGLE,
         CYCLE_PALETTE,
-    ) = range(43)
+        SCREEN_RECORDING_TOGGLE_MP4,
+    ) = range(44)
 
     def __init__(self, event):
         self.__event = event
@@ -420,6 +421,7 @@ class WindowEvent:
             "MOD_SHIFT_OFF",
             "FULL_SCREEN_TOGGLE",
             "CYCLE_PALETTE",
+            "SCREEN_RECORDING_TOGGLE_MP4",
         )[self.__event]
 
 

--- a/tests/test_screen_recorder.py
+++ b/tests/test_screen_recorder.py
@@ -1,0 +1,90 @@
+#
+# License: See LICENSE.md file
+# GitHub: https://github.com/Baekalfen/PyBoy
+#
+
+from pathlib import Path
+
+from PIL import Image, ImageSequence
+
+from pyboy import PyBoy
+from pyboy.utils import WindowEvent
+
+
+def _trace(msg):
+    print(f"[screen-recorder-test] {msg}", flush=True)
+
+
+def _make_pyboy(monkeypatch, tmp_path, default_rom, sample_rate=24000):
+    repo_root = Path(__file__).resolve().parents[1]
+    rom_path = str((repo_root / default_rom).resolve())
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.shutil.which", lambda _: "/usr/bin/ffmpeg")
+    pyboy = PyBoy(rom_path, window="null", sound_emulated=True, sound_sample_rate=sample_rate)
+    pyboy.set_emulation_speed(0)
+    return pyboy
+
+
+def test_screen_recorder_gif_pillow_pipeline(monkeypatch, tmp_path, default_rom):
+    _trace("Starting GIF recorder flow")
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+    ffmpeg_calls = []
+
+    def _fake_subprocess_run(cmd, stdout=None, stderr=None, check=None):
+        ffmpeg_calls.append(cmd)
+        return type("P", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.subprocess.run", _fake_subprocess_run)
+
+    _trace("Toggle ON GIF recording")
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(2, True, True)
+    _trace("Toggle OFF GIF recording")
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    _trace(f"Captured {len(ffmpeg_calls)} ffmpeg calls for GIF")
+    assert ffmpeg_calls == []
+
+    gif_files = list((tmp_path / "recordings").glob("*.gif"))
+    assert len(gif_files) == 1
+
+    with Image.open(gif_files[0]) as gif:
+        frames = list(ImageSequence.Iterator(gif))
+        assert gif.format == "GIF"
+        assert len(frames) >= 1
+        assert frames[0].size == pyboy.screen.image.size
+    assert list((tmp_path / "recordings").glob("screenrec-*")) == []
+
+    pyboy.stop(save=False)
+    _trace("GIF recorder flow finished")
+
+
+def test_screen_recorder_mp4_with_audio(monkeypatch, tmp_path, default_rom):
+    _trace("Starting MP4 recorder flow")
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom, sample_rate=48000)
+    ffmpeg_calls = []
+
+    def _fake_subprocess_run(cmd, stdout=None, stderr=None, check=None):
+        ffmpeg_calls.append(cmd)
+        return type("P", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.subprocess.run", _fake_subprocess_run)
+
+    _trace("Toggle ON MP4 recording")
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+    pyboy.tick(2, True, True)
+    _trace("Toggle OFF MP4 recording")
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+    pyboy.tick(1, True, True)
+
+    _trace(f"Captured {len(ffmpeg_calls)} ffmpeg calls for MP4")
+    assert len(ffmpeg_calls) == 1
+    cmd = ffmpeg_calls[0]
+    _trace(f"MP4 call args: {cmd}")
+    assert "libx264" in cmd
+    assert "aac" in cmd
+    assert "s8" in cmd
+    assert "48000" in cmd
+    pyboy.stop(save=False)
+    _trace("MP4 recorder flow finished")


### PR DESCRIPTION
patch for: #368

- add full support for mp4 + audio

- add new hotkey `U` for toggle `mp4 recording`

- screen recorder backend rewritted to `FFMPEG`

### GIF
<img width="160" height="144" alt="POKEMON RED-2026 05 05-15 54 51" src="https://github.com/user-attachments/assets/cf5682e9-a5c9-4e34-931c-28e465b97799" />

### MP4
https://github.com/user-attachments/assets/56cc2cc3-0ffa-4920-a63f-6966e59073d2


### UNIT TEST TRACE

```bash
uv run python -m pytest -s -vv test_screen_recorder.py  

============================================= test session starts ==============================================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /home/rgedit/Documentos/repo/PyBoy/.venv/bin/python3
cachedir: .pytest_cache
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/rgedit/Documentos/repo/PyBoy
configfile: pyproject.toml
plugins: xdist-3.8.0, benchmark-5.2.3, lazy-fixtures-1.4.0
collected 2 items                                                                                              

test_screen_recorder.py::test_screen_recorder_gif_ffmpeg_pipeline [screen-recorder-test] Starting GIF recorder flow
[screen-recorder-test] Toggle ON GIF recording
[screen-recorder-test] Toggle OFF GIF recording
[screen-recorder-test] Captured 2 ffmpeg calls for GIF
[screen-recorder-test] GIF call #1 args: ['/usr/bin/ffmpeg', '-y', '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s:v', '160x144', '-r', '60', '-i', './recordings/screenrec-53vs8olz/video.rgba', '-vf', 'fps=60,palettegen=stats_mode=diff', './recordings/screenrec-53vs8olz/palette.png']
[screen-recorder-test] GIF call #2 args: ['/usr/bin/ffmpeg', '-y', '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s:v', '160x144', '-r', '60', '-i', './recordings/screenrec-53vs8olz/video.rgba', '-i', './recordings/screenrec-53vs8olz/palette.png', '-lavfi', 'fps=60[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3:diff_mode=rectangle', './recordings/DEFAULT-ROM-2026.05.05-16.46.31.gif']
[screen-recorder-test] GIF recorder flow finished
PASSED
test_screen_recorder.py::test_screen_recorder_mp4_with_audio [screen-recorder-test] Starting MP4 recorder flow
[screen-recorder-test] Toggle ON MP4 recording
[screen-recorder-test] Toggle OFF MP4 recording
[screen-recorder-test] Captured 1 ffmpeg calls for MP4
[screen-recorder-test] MP4 call args: ['/usr/bin/ffmpeg', '-y', '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s:v', '160x144', '-r', '60', '-i', './recordings/screenrec-breuoi5c/video.rgba', '-f', 's8', '-ar', '48000', '-ac', '2', '-i', './recordings/screenrec-breuoi5c/audio.s8', '-c:v', 'libx264', '-preset', 'veryfast', '-crf', '18', '-pix_fmt', 'yuv420p', '-c:a', 'aac', '-b:a', '128k', '-shortest', './recordings/DEFAULT-ROM-2026.05.05-16.46.31.mp4']
[screen-recorder-test] MP4 recorder flow finished
PASSED

============================================== 2 passed in 0.70s ===============================================
```

