### PR TITLE
Prevent screen recordings from overwriting existing files

### DIFF
--- a/pyboy/plugins/screen_recorder.py
+++ b/pyboy/plugins/screen_recorder.py
@@ -3,6 +3,7 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
+import contextlib
 import os
 import shutil
 import subprocess
@@ -87,9 +88,13 @@ class ScreenRecorder(PyBoyPlugin):
         tmpdir = tempfile.mkdtemp(prefix="screenrec-", dir=directory)
         video_raw = os.path.join(tmpdir, "video.rgba")
         audio_raw = os.path.join(tmpdir, "audio.s8")
-        output_path = os.path.join(directory, f"{stamp}.{mode}")
+        try:
+            output_path, reservation_path = self._reserve_output_path(directory, stamp, mode)
+        except Exception:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            raise
 
-        self._session = {
+        session = {
             "mode": mode,
             "tmpdir": tmpdir,
             "video_raw": video_raw if mode == "mp4" else None,
@@ -98,13 +103,53 @@ class ScreenRecorder(PyBoyPlugin):
             "frames": 0,
             "audio_bytes": 0,
             "gif_frames": [] if mode == "gif" else None,
-            "video_fh": open(video_raw, "wb") if mode == "mp4" else None,
-            "audio_fh": open(audio_raw, "wb") if mode == "mp4" else None,
+            "video_fh": None,
+            "audio_fh": None,
+            "reservation_path": reservation_path,
         }
+        try:
+            if mode == "mp4":
+                session["video_fh"] = open(video_raw, "wb")
+                session["audio_fh"] = open(audio_raw, "wb")
+        except Exception:
+            if session["video_fh"] is not None:
+                session["video_fh"].close()
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(output_path)
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(reservation_path)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            raise
+
+        self._session = session
 
         self.recording_gif = mode == "gif"
         self.recording_mp4 = mode == "mp4"
         logger.info("ScreenRecorder started: %s", mode.upper())
+
+    @staticmethod
+    def _reserve_output_path(directory, stamp, mode):
+        suffix = 1
+        output_path = os.path.join(directory, f"{stamp}.{mode}")
+        while True:
+            reservation_path = ScreenRecorder._reservation_path(output_path)
+            if os.path.exists(output_path):
+                output_path = os.path.join(directory, f"{stamp}-{suffix}.{mode}")
+                suffix += 1
+                continue
+            try:
+                fd = os.open(reservation_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                os.close(fd)
+                return output_path, reservation_path
+            except FileExistsError:
+                pass
+            output_path = os.path.join(directory, f"{stamp}-{suffix}.{mode}")
+            suffix += 1
+
+    @staticmethod
+    def _reservation_path(output_path):
+        directory, filename = os.path.split(output_path)
+        return os.path.join(directory, f".{filename}.lock")
 
     def _stop_recording(self):
         session = self._session
@@ -128,6 +173,9 @@ class ScreenRecorder(PyBoyPlugin):
 
         if success:
             logger.info("Screen recording saved in %s", session["output_path"])
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(session["output_path"])
         self._cleanup_session(session)
         self._session = None
         self.recording_gif = False
@@ -225,6 +273,8 @@ class ScreenRecorder(PyBoyPlugin):
     def _cleanup_session(self, session):
         if session.get("gif_frames") is not None:
             session["gif_frames"] = []
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(session["reservation_path"])
         if os.path.exists(session["tmpdir"]):
             shutil.rmtree(session["tmpdir"], ignore_errors=True)
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -56,8 +56,15 @@ def move_gif(game, dest):
     record_dir = "recordings"
     for _ in range(10):
         try:
-            gif = sorted(filter(lambda x: game in x, os.listdir(record_dir)))[-1]
-            os.replace(record_dir + "/" + gif, dest)
+            gif = max(
+                (
+                    entry.path
+                    for entry in os.scandir(record_dir)
+                    if entry.is_file() and entry.name.endswith(".gif") and game in entry.name
+                ),
+                key=os.path.getmtime,
+            )
+            os.replace(gif, dest)
             break
         except:  # noqa
             time.sleep(1)
@@ -172,6 +179,32 @@ def test_pokemon(pokemon_blue_rom, boot_rom):
         stop_frame=1074,
         bootrom_file=boot_rom,
     )
+
+
+def test_move_gif_prefers_newest_matching_gif(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    record_dir = tmp_path / "recordings"
+    record_dir.mkdir()
+
+    older_gif = record_dir / "SUPERMARIOLAND.gif"
+    newer_gif = record_dir / "SUPERMARIOLAND-1.gif"
+    newer_mp4 = record_dir / "SUPERMARIOLAND.mp4"
+
+    older_gif.write_bytes(b"older-gif")
+    newer_gif.write_bytes(b"newer-gif")
+    newer_mp4.write_bytes(b"newer-mp4")
+
+    os.utime(older_gif, (1, 1))
+    os.utime(newer_gif, (2, 2))
+    os.utime(newer_mp4, (3, 3))
+
+    destination = tmp_path / "moved.gif"
+    move_gif("SUPERMARIOLAND", destination)
+
+    assert destination.read_bytes() == b"newer-gif"
+    assert older_gif.exists()
+    assert not newer_gif.exists()
+    assert newer_mp4.exists()
 
 
 @pytest.mark.skip("Outdated base state")

--- a/tests/test_screen_recorder.py
+++ b/tests/test_screen_recorder.py
@@ -136,13 +136,36 @@ def test_screen_recorder_cleans_up_reserved_output_on_start_failure(monkeypatch,
     with pytest.raises(OSError, match="disk full"):
         pyboy.tick(1, True, True)
 
-    assert list((tmp_path / "recordings").glob("*.mp4")) == []
-    assert list((tmp_path / "recordings").glob("screenrec-*")) == []
+    recordings_dir = tmp_path / "recordings"
+    screen_recorder = pyboy._plugin_manager.screen_recorder
+    assert list(recordings_dir.glob("*.mp4")) == []
+    assert list(recordings_dir.glob(".*.lock")) == []
+    assert list(recordings_dir.glob("screenrec-*")) == []
+    assert screen_recorder._session is None
+    assert not screen_recorder.recording_gif
+    assert not screen_recorder.recording_mp4
+
+    def _fake_subprocess_run(cmd, stdout=None, stderr=None, check=None):
+        Path(cmd[-1]).write_bytes(b"mp4")
+        return type("P", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("builtins.open", real_open)
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.subprocess.run", _fake_subprocess_run)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+    pyboy.tick(1, True, True)
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+    pyboy.tick(1, True, True)
+
+    retry_recordings = list(recordings_dir.glob("*.mp4"))
+    assert len(retry_recordings) == 1
+    assert list(recordings_dir.glob(".*.lock")) == []
     pyboy.stop(save=False)
 
 
 def test_screen_recorder_cleans_up_tempdir_on_reservation_failure(monkeypatch, tmp_path, default_rom):
     pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+    real_reserve_output_path = pyboy._plugin_manager.screen_recorder.__class__._reserve_output_path
 
     def _failing_reservation(*args, **kwargs):
         raise OSError("read-only filesystem")
@@ -153,7 +176,26 @@ def test_screen_recorder_cleans_up_tempdir_on_reservation_failure(monkeypatch, t
     with pytest.raises(OSError, match="read-only filesystem"):
         pyboy.tick(1, True, True)
 
-    assert list((tmp_path / "recordings").glob("screenrec-*")) == []
+    recordings_dir = tmp_path / "recordings"
+    screen_recorder = pyboy._plugin_manager.screen_recorder
+    assert list(recordings_dir.glob(".*.lock")) == []
+    assert list(recordings_dir.glob("screenrec-*")) == []
+    assert screen_recorder._session is None
+    assert not screen_recorder.recording_gif
+    assert not screen_recorder.recording_mp4
+
+    monkeypatch.setattr(
+        "pyboy.plugins.screen_recorder.ScreenRecorder._reserve_output_path", staticmethod(real_reserve_output_path)
+    )
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    retry_recordings = list(recordings_dir.glob("*.gif"))
+    assert len(retry_recordings) == 1
+    assert list(recordings_dir.glob(".*.lock")) == []
     pyboy.stop(save=False)
 
 

--- a/tests/test_screen_recorder.py
+++ b/tests/test_screen_recorder.py
@@ -179,6 +179,34 @@ def test_screen_recorder_removes_partial_output_when_encoding_fails(monkeypatch,
     pyboy.stop(save=False)
 
 
+def test_screen_recorder_mp4_does_not_overwrite_existing_recording(monkeypatch, tmp_path, default_rom):
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.time.strftime", lambda _: "same-timestamp")
+    pyboys = [_make_pyboy(monkeypatch, tmp_path, default_rom, sample_rate=48000) for _ in range(2)]
+
+    def _fake_subprocess_run(cmd, stdout=None, stderr=None, check=None):
+        Path(cmd[-1]).write_bytes(b"mp4")
+        return type("P", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.subprocess.run", _fake_subprocess_run)
+
+    for pyboy in pyboys:
+        pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+        pyboy.tick(1, True, True)
+
+    for pyboy in pyboys:
+        pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+        pyboy.tick(1, True, True)
+
+    recordings_dir = tmp_path / "recordings"
+    recordings = sorted(path.name for path in recordings_dir.glob("*.mp4"))
+    assert recordings == ["same-timestamp-1.mp4", "same-timestamp.mp4"]
+    assert list(recordings_dir.glob(".*.lock")) == []
+    assert list(recordings_dir.glob("screenrec-*")) == []
+
+    for pyboy in pyboys:
+        pyboy.stop(save=False)
+
+
 def test_screen_recorder_mp4_with_audio(monkeypatch, tmp_path, default_rom):
     _trace("Starting MP4 recorder flow")
     pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom, sample_rate=48000)

--- a/tests/test_screen_recorder.py
+++ b/tests/test_screen_recorder.py
@@ -3,9 +3,11 @@
 # GitHub: https://github.com/Baekalfen/PyBoy
 #
 
+import builtins
 from pathlib import Path
 
 from PIL import Image, ImageSequence
+import pytest
 
 from pyboy import PyBoy
 from pyboy.utils import WindowEvent
@@ -58,6 +60,123 @@ def test_screen_recorder_gif_pillow_pipeline(monkeypatch, tmp_path, default_rom)
 
     pyboy.stop(save=False)
     _trace("GIF recorder flow finished")
+
+
+def test_screen_recorder_does_not_overwrite_existing_recording(monkeypatch, tmp_path, default_rom):
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.time.strftime", lambda _: "same-timestamp")
+    pyboys = [_make_pyboy(monkeypatch, tmp_path, default_rom) for _ in range(2)]
+
+    for pyboy in pyboys:
+        pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+        pyboy.tick(1, True, True)
+
+    for pyboy in pyboys:
+        pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+        pyboy.tick(1, True, True)
+
+    recordings = sorted(path.name for path in (tmp_path / "recordings").glob("*.gif"))
+    assert recordings == ["same-timestamp-1.gif", "same-timestamp.gif"]
+
+    for pyboy in pyboys:
+        pyboy.stop(save=False)
+
+
+def test_screen_recorder_hides_reserved_output_until_save(monkeypatch, tmp_path, default_rom):
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.time.strftime", lambda _: "same-timestamp")
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    recordings_dir = tmp_path / "recordings"
+    assert list(recordings_dir.glob("*.gif")) == []
+    assert list(recordings_dir.glob(".*.lock")) == [recordings_dir / ".same-timestamp.gif.lock"]
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    assert list(recordings_dir.glob("*.gif")) == [recordings_dir / "same-timestamp.gif"]
+    assert list(recordings_dir.glob(".*.lock")) == []
+    pyboy.stop(save=False)
+
+
+def test_screen_recorder_does_not_overwrite_existing_saved_recording(monkeypatch, tmp_path, default_rom):
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.time.strftime", lambda _: "same-timestamp")
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    original_gif = recordings_dir / "same-timestamp.gif"
+    original_gif.write_bytes(b"original-recording")
+
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    recordings = sorted(path.name for path in recordings_dir.glob("*.gif"))
+    assert recordings == ["same-timestamp-1.gif", "same-timestamp.gif"]
+    assert original_gif.read_bytes() == b"original-recording"
+
+    pyboy.stop(save=False)
+
+
+def test_screen_recorder_cleans_up_reserved_output_on_start_failure(monkeypatch, tmp_path, default_rom):
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom, sample_rate=48000)
+    real_open = builtins.open
+
+    def _failing_open(path, mode="r", *args, **kwargs):
+        if path.endswith("audio.s8") and "w" in mode:
+            raise OSError("disk full")
+        return real_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _failing_open)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE_MP4)
+    with pytest.raises(OSError, match="disk full"):
+        pyboy.tick(1, True, True)
+
+    assert list((tmp_path / "recordings").glob("*.mp4")) == []
+    assert list((tmp_path / "recordings").glob("screenrec-*")) == []
+    pyboy.stop(save=False)
+
+
+def test_screen_recorder_cleans_up_tempdir_on_reservation_failure(monkeypatch, tmp_path, default_rom):
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+
+    def _failing_reservation(*args, **kwargs):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.ScreenRecorder._reserve_output_path", _failing_reservation)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    with pytest.raises(OSError, match="read-only filesystem"):
+        pyboy.tick(1, True, True)
+
+    assert list((tmp_path / "recordings").glob("screenrec-*")) == []
+    pyboy.stop(save=False)
+
+
+def test_screen_recorder_removes_partial_output_when_encoding_fails(monkeypatch, tmp_path, default_rom):
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.time.strftime", lambda _: "same-timestamp")
+    pyboy = _make_pyboy(monkeypatch, tmp_path, default_rom)
+
+    def _failing_encode(self, session):
+        Path(session["output_path"]).write_bytes(b"partial-gif")
+        return False
+
+    monkeypatch.setattr("pyboy.plugins.screen_recorder.ScreenRecorder._encode_gif", _failing_encode)
+
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+    pyboy.send_input(WindowEvent.SCREEN_RECORDING_TOGGLE)
+    pyboy.tick(1, True, True)
+
+    recordings_dir = tmp_path / "recordings"
+    assert list(recordings_dir.glob("*.gif")) == []
+    assert list(recordings_dir.glob(".*.lock")) == []
+    assert list(recordings_dir.glob("screenrec-*")) == []
+    pyboy.stop(save=False)
 
 
 def test_screen_recorder_mp4_with_audio(monkeypatch, tmp_path, default_rom):


### PR DESCRIPTION
## Summary
- reserve screen recording filenames before recording starts
- avoid overwriting existing GIF/MP4 recordings with the same timestamp
- clean up reserved files when recording startup fails

## Tests
- python3 -c 'import sys, types, pytest; sys.modules["git"] = types.ModuleType("git"); sys.exit(pytest.main(["-q", "-o", "addopts=", "tests/test_screen_recorder.py", "tests/test_replay.py"]))'
- python3 -m ruff check pyboy/plugins/screen_recorder.py tests/test_screen_recorder.py tests/test_replay.py
- python3 -m ruff format --check pyboy/plugins/screen_recorder.py tests/test_screen_recorder.py tests/test_replay.py