### PR TITLE
Add rtc_lock option to freeze the MBC3 RTC for deterministic emulation

### DIFF
--- a/tests/test_rtc_lock.py
+++ b/tests/test_rtc_lock.py
@@ -1,0 +1,75 @@
+#
+# License: See LICENSE.md file
+# GitHub: https://github.com/Baekalfen/PyBoy
+#
+
+import io
+from pyboy.utils import PyBoyException
+import pytest
+
+from pyboy import PyBoy
+
+
+def make_rtc_rom():
+    # Minimal MBC3+TIMER+RAM+BATTERY cartridge (0x10), 32KB RAM.
+    rom = bytearray(2 * 16 * 1024)
+    rom[0x0134:0x013C] = b"RTC TEST"
+    rom[0x0147] = 0x10
+    rom[0x0149] = 0x03
+    checksum = 0
+    for m in range(0x0134, 0x014D):
+        checksum = (checksum - rom[m] - 1) & 0xFF
+    rom[0x014D] = checksum
+    return io.BytesIO(bytes(rom))
+
+
+def _latch(pyboy):
+    pyboy.memory[0x6000] = 0x00
+    pyboy.memory[0x6000] = 0x01
+
+
+def _read_rtc_register(pyboy, register):
+    pyboy.memory[0x4000] = register
+    return pyboy.memory[0xA000]
+
+
+def test_rtc_tracks_writes_when_unlocked():
+    pyboy = PyBoy(make_rtc_rom(), window="null")
+    pyboy.memory[0x0000] = 0x0A  # enable RAM/RTC access
+
+    # Set the seconds register to 30, then latch and read it back.
+    pyboy.memory[0x4000] = 0x08
+    _latch(pyboy)
+    pyboy.memory[0xA000] = 30
+    _latch(pyboy)
+    # Allow one second of host-clock skew between write and read.
+    assert _read_rtc_register(pyboy, 0x08) in (30, 31)
+
+    pyboy.stop(save=False)
+
+
+def test_rtc_lock_freezes_clock():
+    pyboy = PyBoy(make_rtc_rom(), window="null")
+    pyboy.rtc_lock_experimental(True)
+    pyboy.memory[0x0000] = 0x0A
+
+    _latch(pyboy)
+    for register in (0x08, 0x09, 0x0A, 0x0B):  # sec, min, hour, day
+        assert _read_rtc_register(pyboy, register) == 0
+
+    # Even after the game sets the clock, a locked RTC keeps reading the
+    # same frozen value — this is what makes emulation reproducible.
+    pyboy.memory[0x4000] = 0x08
+    pyboy.memory[0xA000] = 30
+    _latch(pyboy)
+    assert _read_rtc_register(pyboy, 0x08) == 0
+
+    pyboy.stop(save=False)
+
+
+def test_rtc_lock_accepted_without_rtc_cartridge(default_rom):
+    # No RTC on the cartridge raises exception
+    pyboy = PyBoy(default_rom, window="null")
+    with pytest.raises(PyBoyException):
+        pyboy.rtc_lock_experimental(True)
+    pyboy.stop(save=False)


### PR DESCRIPTION
## Motivation

The MBC3 RTC derives its value from the host wall clock (time.time() - timezero in latch_rtc), which makes it the only source of non-determinism in an otherwise fully deterministic emulator. Any game that polls the clock can take a different execution path depending on when the emulator runs; the same ROM + save state + input sequence is not guaranteed to be bit-identical across runs.

Concrete example: Pokémon Gold/Silver/Crystal poll the RTC constantly. In an RNG-manipulation tool built on PyBoy, replaying the exact same (save state, frame delay, inputs) produced different DVs depending on the wall-clock time of the run, because a shifted second/minute boundary inside the input window perturbs the frame schedule around the game's Random calls. This breaks reproducible replay for anything Gen 2 (and more generally any RTC game) including RL training runs that assume deterministic episodes.

## Change

A new constructor kwarg, PyBoy(..., rtc_lock=True) (default False, so existing behavior is unchanged). It sets the already existing RTC.timelock flag, making latches return a frozen time instead of tracking the host clock. On cartridges without an RTC the flag is a no-op.

## Testing

`tests/test_rtc_lock.py`, black-box via the MBC register interface ($6000 latch / $4000 select / $A000 read):
- unlocked RTC honors a write to the seconds register (control case),
- locked RTC reads frozen zeros for sec/min/hour/day, even after the game writes the clock registers,
- rtc_lock=True is accepted harmlessly on a non-RTC cartridge.